### PR TITLE
feat: add SARIF output format for policy violations

### DIFF
--- a/.github/copilot-code-review-instructions.md
+++ b/.github/copilot-code-review-instructions.md
@@ -1,0 +1,254 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Copilot Code Review Instructions for regorus
+
+regorus is a security-critical multi-policy-language evaluation engine used in
+production at Azure scale. Behavioral bugs are security bugs.
+
+## Your Role
+
+You are a thorough, independent reviewer. Use your own judgment to determine
+the best review strategy for each change. Read the diff, understand the intent,
+explore the surrounding code, and consult the knowledge files that are relevant.
+You decide what to focus on, what to investigate deeper, and when the review is
+complete.
+
+Do not follow a rigid checklist. Think freely. The domain knowledge below is
+context to inform your thinking — not a script to execute.
+
+## Severity Categories
+
+Categorize findings so the author can triage effectively:
+
+- 🔴 **Correctness** — wrong result, logic error, behavioral bug
+- 🟠 **Security** — could affect policy evaluation, resource limits, DoS vector
+- 🟡 **Robustness** — panic path, missing error handling, unchecked arithmetic
+- 🔵 **Polish** — code duplication, naming, style, documentation, dead code
+- ⚪ **Nit** — minor style preference (only flag if pattern is inconsistent)
+
+Always flag 🔴 and 🟠 findings. Never dismiss them as minor.
+
+## Multi-Scale Thinking
+
+Good reviews naturally move between scales. Let the change guide you:
+
+- **Line-level** — is this line correct? What if the input is unexpected?
+- **File/concept-level** — does this fit its module? Duplication? Naming?
+  Is the abstraction right? Could this be simpler?
+- **Big picture** — does this affect the evaluation contract? Other subsystems?
+  Bindings? Security posture? Will this surprise a future maintainer?
+
+You decide which scale matters most for each change. A one-line fix in
+`value.rs` may need deep big-picture thinking. A large refactor may mostly
+need file-level polish review.
+
+## Comment Format (REQUIRED)
+
+Every review comment you write MUST begin with this exact structure — no exceptions:
+
+**Line 1:** `**[Perspective]** SEVERITY`
+**Line 2:** `> One-sentence issue title suitable for a GitHub issue`
+**Line 3+:** Your detailed explanation
+
+Where:
+- **Perspective** is one of: `Red Teamer`, `Semantics Expert`, `Architect`, `Performance Engineer`, `Test Engineer`, `Security Auditor`, `Reliability Engineer`, `Support Engineer`, `API Steward`, `Refactorer`, `CI/CD Security`
+- **SEVERITY** is one of: `🔴 critical`, `🟠 important`, `🔵 suggestion`
+
+Here are two examples of correctly formatted comments:
+
+**[Reliability Engineer]** 🔴 critical
+> strings.repeat panics on non-numeric input via unwrap()
+
+`args[1].as_f64().unwrap()` panics when the argument is not numeric.
+Use `ensure_numeric()` and return Undefined for invalid inputs.
+
+**[Red Teamer]** 🟠 important
+> strings.repeat allows unbounded allocation (DoS vector)
+
+No call to `enforce_limit()` during string growth. A malicious policy
+can pass a huge count to exhaust memory.
+
+If a comment does not clearly map to one perspective, use the closest match.
+Every comment must have exactly one perspective tag — this tells the maintainer
+*which concern* identified the issue and helps them file tracking issues.
+
+## Review Perspectives
+
+Adopt these perspectives during your review. You cannot launch subagents, so
+**think from each relevant perspective yourself**. Not every perspective applies
+to every change — select the ones that matter based on what changed.
+
+For deeper guidance on any perspective, read the corresponding agent file from
+`.github/agents/` — each contains detailed domain-specific checklists.
+
+### 🔴 Red Teamer (`red-teamer.agent.md`)
+Think like an attacker who has read the source code. Can this change be exploited
+with pathological inputs? Deeply nested JSON → stack overflow? Enormous strings →
+OOM? Policies designed to exploit quadratic evaluation? Can Undefined propagation
+be weaponized to flip a policy decision?
+
+### 🧠 Semantics Expert (`semantics-expert.agent.md`)
+Does this match the OPA/Rego specification exactly? Is Undefined handled correctly
+in every expression? Do interpreter and RVM produce identical results? Are `with`
+overrides restored on exit? Does rule conflict resolution follow spec?
+
+### 🏗️ Architect (`architect.agent.md`)
+Does this respect module boundaries? How does it affect the 9 FFI bindings? Does
+it compile with `--no-default-features`? Will it block planned features (language
+servers, partial evaluation, daemon mode)? Is the API change backward compatible?
+
+### ⚡ Performance Engineer (`performance-engineer.agent.md`)
+Are there allocations in the evaluation hot path? Clone where borrow suffices?
+O(n²) patterns? Temporary collections built just to iterate once? Would this
+change benefit from a benchmark?
+
+### 🧪 Test Engineer (`test-engineer.agent.md`)
+Are new code paths tested? Both interpreter AND RVM paths? Edge cases: empty
+collections, Undefined operands, type mismatches, boundary values? Are tests
+testing behavior (not implementation)? Would property-based testing help?
+
+### 🔒 Security Auditor (`security-auditor.agent.md`)
+What trust boundaries are crossed? Are resource limits preserved? Any new
+dependencies — are they audited and no_std compatible? Actions pinned by SHA?
+Can the error path leak sensitive information?
+
+### 🛡️ Reliability Engineer (`reliability-engineer.agent.md`)
+Is evaluation still deterministic? Any new panic paths (`unwrap`, unchecked index)?
+Are resources bounded and cleaned up on all exit paths? When limits are hit, is
+the error clear and actionable?
+
+### 🔧 Support Engineer (`support-engineer.agent.md`)
+Do error messages include source location? Can an operator diagnose the issue
+without reading regorus source? Are error chains preserved through wrapping?
+Does this change preserve or improve diagnostic information?
+
+### 📋 API Steward (`api-steward.agent.md`)
+Does this change the public API? Is it backward compatible? Does it need a semver
+bump? Are all 9 bindings updated? Is there a deprecation path? Is the CHANGELOG
+updated?
+
+### 🔄 Refactorer (`refactorer.agent.md`)
+Is there duplicated logic that should be shared? Functions over 50 lines that
+should be decomposed? Dead code? Inconsistent patterns? Could newer Rust features
+simplify this?
+
+### 🛡️ CI/CD Security (`ci-cd-security.agent.md`)
+Does this change workflows, shell scripts, or automation configs? Look for
+expression injection (`${{ }}` in `run:` blocks), GITHUB_OUTPUT injection via
+newlines, unquoted heredocs with untrusted content, predictable temp files,
+path traversal in script dispatch, and model output posted without sanitization.
+This perspective is essential for any PR touching `.yml`, `.sh`, or `.json`
+config files.
+
+## Domain Knowledge
+
+This is what makes regorus unique. Internalize this context and let it inform
+your review — but decide for yourself what matters for each specific change.
+
+### Three-Valued Logic and Undefined
+
+regorus uses three-valued logic: `true`, `false`, `Undefined`. This is the
+most common source of subtle bugs.
+
+- `Undefined` is **not** `false` — treating it as false is a bug
+- `not Undefined` evaluates to `true` — correct but surprising
+- Any expression with a potentially-undefined operand needs both-path thinking
+- Default rules exist to handle undefined — consider if one is needed
+
+### Cross-Cutting Impact Vectors
+
+Changes in regorus often have non-obvious ripple effects:
+
+- **9 language bindings** — API changes affect C, C++, C#, Go, Java, Python,
+  Ruby, Rust, and WASM targets. Panic safety is critical at FFI boundaries.
+- **Dual execution paths** — interpreter and RVM must produce identical results
+- **Feature flag matrix** — must compile with `--all-features`,
+  `--no-default-features`, and the `arc` feature (Rc→Arc, RefCell→RwLock)
+- **no_std discipline** — `core::`/`alloc::` by default, `std::` only behind
+  `#[cfg(feature = "std")]`
+
+### Safety Invariants
+
+The codebase enforces these — watch for violations:
+
+- `#![forbid(unsafe_code)]` in core crate (only FFI bindings may use unsafe)
+- 80+ deny lints — `#[allow(...)]` additions need strong justification
+- No `.unwrap()` / `.expect()` / unchecked indexing in library code
+- No unchecked arithmetic — use `checked_add()`, `saturating_mul()`, etc.
+- RVM instruction budget (default 25,000) bounds computation
+- Error handling: `thiserror` in new code, `anyhow` acceptable in existing modules
+
+### Security Awareness
+
+regorus evaluates policy at scale — think adversarially:
+
+- Can an adversarial policy or input cause unbounded computation/memory/recursion?
+- Does this trust external input without validation?
+- Does a dependency change expand the attack surface?
+- Could a behavioral change flip a policy decision in production?
+
+### Telemetry and Diagnostics
+
+regorus aims for cloud-scale debuggability. Consider:
+
+- **Error traceability**: do error messages include source location (file:line:col)?
+  Can an operator trace an error back to the policy rule that caused it?
+- **Structured errors**: are new errors machine-parseable? Do they carry enough
+  context for diagnosis without reading source code?
+- **Diagnostic preservation**: does this change preserve or improve the diagnostic
+  information available to users? Watch for error conversions that lose context.
+- **No secrets in errors**: error messages must never include policy content or
+  input data values — only paths, types, and structural information.
+
+Consult: `telemetry-and-diagnostics.md`
+
+## Polish and Code Quality
+
+Good reviews catch more than bugs. Look for opportunities to improve:
+
+- **Code duplication** — similar logic that should be unified
+- **Naming** — variables that describe how, not what; overly generic type names
+- **Dead code** — commented-out code, unused imports, unjustified `#[allow(dead_code)]`
+- **Missing documentation** — public functions without doc comments, complex
+  algorithms without "why" comments
+- **Simplification** — could this be expressed more clearly or concisely?
+
+## Deep Reference: Knowledge Files
+
+When you need deeper understanding of a subsystem, read the relevant knowledge
+file from `docs/knowledge/`. These contain institutional knowledge that is not
+obvious from the code alone.
+
+| File | Domain |
+|------|--------|
+| `value-semantics.md` | Value types, Undefined propagation, three-valued logic |
+| `rvm-architecture.md` | VM execution modes, frame stack, serialization |
+| `rego-compiler.md` | Rego compilation, worklist algorithm, register allocation |
+| `compilation-pipeline.md` | Scheduler, loop hoisting, destructuring planner |
+| `builtin-system.md` | Builtin registration, feature gating, OPA conformance |
+| `ffi-boundary.md` | Handle pattern, panic containment, 9 binding targets |
+| `feature-composition.md` | Feature flag interactions, no_std boundary |
+| `error-handling-migration.md` | anyhow → thiserror strategy, VmError pattern |
+| `policy-evaluation-security.md` | DoS protection, resource limits, supply chain |
+| `rego-semantics.md` | Evaluation model, backtracking, `with` modifier |
+| `interpreter-architecture.md` | Context stack, scope management, rule lifecycle |
+| `azure-policy-language.md` | Azure Policy evaluation, effects, conditions |
+| `azure-policy-aliases.md` | Alias registry, ARM normalization pipeline |
+| `azure-rbac-language.md` | RBAC condition interpreter, ABAC builtins |
+| `engine-api.md` | Public API surface, add_policy → compile → eval flow |
+| `time-builtins-compat.md` | Go time.Parse compatibility, timezone handling |
+| `language-extension-guide.md` | Adding new policy languages, extensibility |
+| `tooling-architecture.md` | Language server, linter, analyzer patterns |
+| `workflow-security.md` | GitHub Actions security, shell hardening, model output |
+| `causality-and-partial-eval.md` | Causality tracking, partial evaluation design |
+
+You decide which files are relevant. Not every review needs every file.
+
+## Review Iteration
+
+Thorough review is iterative. After findings are addressed, review again.
+Each pass catches things the previous one missed. Keep going until no
+significant (🔴🟠🟡) findings remain.
+
+A change is ready when you would trust it in production at scale.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,139 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Regorus — Copilot Instructions
+
+> If these instructions conflict with the actual codebase, the code is the
+> source of truth. Flag any discrepancy you notice.
+
+## Identity
+
+Regorus is a **multi-policy-language evaluation engine** written in Rust. Its
+primary language is [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/)
+(Open Policy Agent), with extensible support for additional policy languages via
+`src/languages/`. It is used in **production at scale** where **correctness is
+security-critical** — a bug in policy evaluation can mean `allow` when the
+answer should be `deny`.
+
+**Key properties:**
+- 10 language targets: Rust (core), C, C (no_std), C++, C#, Go, Java, Python, Ruby, WASM
+- `#![no_std]` by default (`extern crate alloc`), `#![forbid(unsafe_code)]`
+- Two execution paths: tree-walking interpreter and **RVM** (bytecode VM)
+- 80+ deny lints in `src/lib.rs` — restricts panics, unchecked indexing, and unchecked arithmetic
+  (some modules like `value.rs` locally `#![allow(...)]` specific lints for performance)
+
+**Strategic direction:**
+- **RVM is the strategic execution path** — new optimization work focuses there
+- **Isolated / daemon execution** — long-lived process, clean resource lifecycle
+- **Error migration** — `anyhow` → `thiserror` strongly typed errors (RVM leads)
+- **Formal verification** — Miri (active CI), Z3 and Verus (planned)
+- **Multi-policy-language** — extensible via `src/languages/`, don't disclose specifics
+
+## Deep Knowledge
+
+For complex subsystems, read the knowledge files in `docs/knowledge/` before
+making changes. These capture invariants, edge cases, and institutional
+knowledge that isn't obvious from the code alone:
+
+| File | Covers |
+|------|--------|
+| `value-semantics.md` | Value type, Undefined propagation, three-valued logic |
+| `rvm-architecture.md` | VM execution modes, frame stack, serialization, register pooling |
+| `builtin-system.md` | Builtin registration, feature gating, OPA conformance |
+| `ffi-boundary.md` | Safety across 9 bindings, handles, panic containment, poisoning |
+| `feature-composition.md` | Feature flag interactions, no_std boundary, testing matrix |
+| `error-handling-migration.md` | anyhow → thiserror migration strategy, VmError pattern |
+| `policy-evaluation-security.md` | DoS protection, resource limits, input validation |
+| `rego-semantics.md` | Evaluation model, undefined propagation, backtracking, `with` |
+| `interpreter-architecture.md` | Context stack, scope management, rule lifecycle |
+| `compilation-pipeline.md` | Scheduler, loop hoisting, destructuring planner |
+| `azure-policy-language.md` | Azure Policy evaluation model, effects, alias normalization |
+| `azure-rbac-language.md` | RBAC condition interpreter, ABAC builtins, context model |
+| `engine-api.md` | Public API surface, add_policy → compile → eval flow |
+| `time-builtins-compat.md` | Go time.Parse compatibility, timezone handling |
+| `language-extension-guide.md` | Adding new policy languages, LSP/tooling vision |
+| `tooling-architecture.md` | Language server, linter, analyzer design patterns |
+| `causality-and-partial-eval.md` | Causality tracking and partial evaluation design |
+| `rego-compiler.md` | Worklist algorithm, expression codegen, register allocation |
+| `azure-policy-aliases.md` | Alias registry, ARM normalization/denormalization pipeline |
+| `telemetry-and-diagnostics.md` | Error traceability, structured diagnostics, cloud-scale telemetry |
+| `workflow-security.md` | GitHub Actions security patterns, expression injection, token handling |
+
+Also see `docs/rvm/architecture.md`, `docs/rvm/instruction-set.md`,
+`docs/rvm/vm-runtime.md` for RVM internals.
+
+## Essential Coding Rules
+
+**No panics — ever** (deny lints enforce this):
+```rust
+// Use typed errors for new code
+let v = map.get("key").ok_or(MyError::MissingKey("key"))?;
+// Or anyhow in existing modules
+let v = map.get("key").ok_or_else(|| anyhow!("missing key"))?;
+```
+
+**Prefer safe indexing** — use `.get()` + `?` or iterate where possible.
+`clippy::indexing_slicing` is denied crate-wide but locally allowed in some
+performance-critical modules (e.g., `value.rs`).
+
+**No unchecked arithmetic** — use `checked_add()`, `saturating_add()`, etc.
+
+**no_std discipline** — `use core::` and `alloc::` by default. Only `std::`
+behind `#[cfg(feature = "std")]`.
+
+**Unsafe forbidden** — `#![forbid(unsafe_code)]` in the core crate. Only FFI
+binding crates may use unsafe.
+
+**Error handling** — new modules: `thiserror` enums (see `src/rvm/vm/errors.rs`).
+Existing modules: `anyhow` is acceptable for consistency within the module.
+
+**Feature gating** — gate modules, registrations, and public API. Add `docsrs`
+annotation. Verify non-default combinations compile.
+
+## Build & Test
+
+```bash
+cargo xtask ci-debug          # Full debug CI suite
+cargo xtask ci-release        # Full release CI suite (superset)
+cargo xtask test-all-bindings # All 9 language binding smoke tests
+cargo xtask test-no-std       # Verify no_std builds (thumbv7m-none-eabi)
+cargo xtask fmt               # Format workspace + bindings
+cargo xtask clippy            # Lint workspace + bindings
+cargo test --test opa         # OPA conformance (needs opa-testutil feature)
+```
+
+Git hooks auto-installed by `build.rs`: pre-commit (build+format+clippy),
+pre-push (+ doc tests + no_std + OPA conformance).
+
+## Repository Layout
+
+```
+src/                    Core library (no_std, forbid(unsafe_code))
+  rvm/                  Rego Virtual Machine ← strategic focus
+  languages/            Policy language extensions
+  builtins/             Builtin functions (~19 modules)
+  value.rs              Value type (Null, Bool, Number, String, Array, Set, Object, Undefined)
+  interpreter.rs        Tree-walking interpreter (legacy path)
+  engine.rs             Public API
+bindings/               9 language bindings + ffi layer (c/, c-nostd/, cpp/, csharp/, go/, java/, python/, ruby/, wasm/)
+tests/                  Integration, conformance, domain-specific tests
+docs/                   Grammar, builtins, RVM docs, knowledge base
+xtask/                  Development automation CLI
+benches/                Criterion benchmarks
+```
+
+## Supply Chain Security
+
+- `dependency-audit.yml` — cargo-audit + cargo-deny across all Cargo.lock files
+- Dependabot — weekly updates for Cargo, Actions, Maven, NuGet, pip, npm, bundler, Go
+- New GitHub Actions references added in this config use pinned commit SHAs
+- `cargo fetch --locked` / `--frozen` in CI for reproducible builds
+
+## When Making Changes
+
+1. **Read relevant knowledge files** in `docs/knowledge/` first
+2. **Consider all 9 binding targets** — API changes affect every language
+3. **Both execution paths** — features must work in interpreter AND RVM
+4. **Test Undefined propagation** — `Undefined ≠ false`, test both paths
+5. **Run `cargo xtask ci-debug`** before submitting
+6. **Update docs** — `docs/builtins.md`, `docs/rvm/`, knowledge files as needed

--- a/.github/prompts/audit-api-ergonomics.json
+++ b/.github/prompts/audit-api-ergonomics.json
@@ -1,0 +1,5 @@
+{
+  "topic": "API ergonomics — confusing public interfaces, missing builder patterns, inconsistent naming, poor error messages, and documentation gaps in the public API",
+  "perspectives": "api-steward,dx-engineer,architect",
+  "description": "Reviews the public API surface from the perspective of downstream consumers across all 9 language bindings."
+}

--- a/.github/prompts/audit-code-cleanup.json
+++ b/.github/prompts/audit-code-cleanup.json
@@ -1,0 +1,5 @@
+{
+  "topic": "code cleanup — dead code, duplicated logic, overly complex functions, unclear naming, stale comments, and opportunities to simplify",
+  "perspectives": "refactorer,architect,reliability-engineer",
+  "description": "Finds concrete cleanup opportunities that reduce complexity without changing behavior."
+}

--- a/.github/prompts/audit-design-alternatives.json
+++ b/.github/prompts/audit-design-alternatives.json
@@ -1,0 +1,5 @@
+{
+  "topic": "design alternatives — areas where a different data structure, algorithm, abstraction, or API design would simplify code, improve correctness, or reduce maintenance burden",
+  "perspectives": "architect,semantics-expert,refactorer",
+  "description": "Surfaces structural improvements and alternative approaches that could make the codebase simpler or more robust."
+}

--- a/.github/prompts/audit-ffi-boundary.json
+++ b/.github/prompts/audit-ffi-boundary.json
@@ -1,0 +1,5 @@
+{
+  "topic": "FFI boundary safety — memory safety, panic containment, handle validation, and error propagation across language boundaries",
+  "perspectives": "security-auditor,architect,api-steward,reliability-engineer",
+  "description": "Audits all FFI bindings (C, Python, Ruby, Java, Go, C#, WASM) for safety invariants."
+}

--- a/.github/prompts/audit-knowledge-accuracy.json
+++ b/.github/prompts/audit-knowledge-accuracy.json
@@ -1,0 +1,6 @@
+{
+  "topic": "knowledge documentation accuracy — compare docs/knowledge/*.md against actual source code for inaccuracies, stale descriptions, deleted files, and coverage gaps",
+  "perspectives": "auto",
+  "script": "knowledge-accuracy",
+  "description": "Compares each knowledge file against its referenced source code. Detects factual errors, stale content from refactoring, deleted/renamed files, and important source files with no documentation."
+}

--- a/.github/prompts/audit-panic-safety.json
+++ b/.github/prompts/audit-panic-safety.json
@@ -1,0 +1,5 @@
+{
+  "topic": "panic safety — unwrap, expect, index without bounds check, and potential panics in production code paths",
+  "perspectives": "reliability-engineer,security-auditor,semantics-expert",
+  "description": "Finds all potential panic points in non-test code. Critical for a no_std-compatible library used in Azure production."
+}

--- a/.github/prompts/audit-performance.json
+++ b/.github/prompts/audit-performance.json
@@ -1,0 +1,5 @@
+{
+  "topic": "performance bottlenecks — hot paths, unnecessary allocations, redundant cloning, inefficient data structures, and missed optimization opportunities",
+  "perspectives": "performance-engineer,architect,reliability-engineer",
+  "description": "Identifies performance regressions and optimization opportunities across evaluation, compilation, and builtin execution paths."
+}

--- a/.github/prompts/audit-resource-limits.json
+++ b/.github/prompts/audit-resource-limits.json
@@ -1,0 +1,5 @@
+{
+  "topic": "resource limits and DoS protection — enforce_limit usage, recursion depth, output size caps, timeout handling, and memory bounds",
+  "perspectives": "security-auditor,reliability-engineer,performance-engineer",
+  "description": "Ensures all code paths that could consume unbounded resources are properly guarded."
+}

--- a/.github/prompts/audit-security-hardening.json
+++ b/.github/prompts/audit-security-hardening.json
@@ -1,0 +1,5 @@
+{
+  "topic": "security hardening — input validation, resource limits, DoS protection, untrusted policy handling, and supply chain safety",
+  "perspectives": "security-auditor,red-teamer,reliability-engineer",
+  "description": "Comprehensive security review of the policy engine. Focuses on attack surfaces exposed to untrusted inputs."
+}

--- a/.github/prompts/audit-test-gaps.json
+++ b/.github/prompts/audit-test-gaps.json
@@ -1,0 +1,5 @@
+{
+  "topic": "test coverage gaps — untested code paths, missing edge cases, weak assertions, and areas where property-based or fuzz testing would add value",
+  "perspectives": "test-engineer,semantics-expert,red-teamer",
+  "description": "Identifies where testing is weakest relative to code complexity and risk."
+}

--- a/.github/prompts/audit-undefined-propagation.json
+++ b/.github/prompts/audit-undefined-propagation.json
@@ -1,0 +1,5 @@
+{
+  "topic": "undefined value propagation — three-valued logic correctness, Undefined handling in builtins, partial sets, comprehensions, and rule evaluation",
+  "perspectives": "semantics-expert,test-engineer,reliability-engineer",
+  "description": "Verifies correct Undefined/three-valued logic handling throughout the evaluation pipeline. Rego's most subtle semantics."
+}

--- a/.github/skills/add-builtin/SKILL.md
+++ b/.github/skills/add-builtin/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: add-builtin
+description: >-
+  Guide for adding new builtin functions to regorus. Use this skill when asked
+  to add a new builtin, implement a missing OPA builtin, or extend the builtin
+  system.
+allowed-tools: shell
+---
+
+# Add Builtin Skill
+
+Adding a builtin to regorus requires changes in multiple places and careful
+attention to feature gating, type safety, and OPA conformance.
+
+## Overview
+
+Read `docs/knowledge/builtin-system.md` first for the full registration
+architecture.
+
+## Steps to Add a Builtin
+
+### 1. Choose the Right Module
+
+Builtins are organized by category in `src/builtins/`:
+
+```
+src/builtins/
+  aggregates.rs    # count, sum, max, min, sort
+  arrays.rs        # array.concat, array.slice, array.reverse
+  bitwise.rs       # bits.and, bits.or, bits.negate, etc.
+  comparison.rs    # comparison operators
+  conversions.rs   # to_number, units.parse, units.parse_bytes
+  encoding.rs      # base64, json, yaml, hex, urlquery, crypto
+  glob.rs          # glob.match, glob.quote_meta
+  graph.rs         # graph.reachable, graph.reachable_paths
+  http.rs          # http.send
+  net.rs           # net.cidr_contains, net.cidr_merge
+  numbers.rs       # rand.intn, numbers.range, ceil, floor
+  objects.rs       # object.get, object.union, object.filter
+  opa.rs           # opa.runtime
+  regex.rs         # regex.match, regex.split, regex.find
+  semver.rs        # semver.compare, semver.is_valid
+  sets.rs          # intersection, union
+  strings.rs       # concat, contains, sprintf, etc.
+  time/            # time.now_ns, time.parse_ns, etc.
+  types.rs         # is_string, is_number, type_name
+  azure_policy/    # Azure Policy-specific builtins
+```
+
+Add your builtin to the appropriate existing module, or create a new module
+if it represents a new category.
+
+### 2. Implement the Function
+
+```rust
+fn my_builtin(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
+    // Validate argument count
+    ensure_args_count(span, "my_builtin", params, args, expected_count)?;
+
+    // Type-check arguments — strict mode raises errors, non-strict returns Undefined
+    let arg0 = match &args[0] {
+        Value::String(s) => s,
+        a if strict => {
+            let span = params[0].span();
+            bail!(span.error(
+                format!("`my_builtin` requires string argument. Got `{a}`.").as_str()
+            ))
+        }
+        _ => return Ok(Value::Undefined),
+    };
+
+    // Implement the logic
+    // ...
+
+    Ok(result)
+}
+```
+
+Key patterns:
+- **Return `Value::Undefined`** for type mismatches in non-strict mode (OPA semantics)
+- **Return `Err`** for type mismatches in strict mode, and for genuine errors (wrong arg count, internal failure)
+- **Use `strict` parameter** for strict mode behavior differences
+- **Handle `Value::Undefined` inputs** — decide: propagate or treat as error
+
+### 3. Register the Builtin
+
+In the same module, add to the registration function:
+
+```rust
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
+    m.insert("my_category.my_builtin", (my_builtin, 2));
+    // ...
+}
+```
+
+The tuple is `(function_pointer, expected_arg_count)`.
+
+### 4. Feature Gate (if needed)
+
+If the builtin depends on an optional crate or is language-specific:
+
+```rust
+#[cfg(feature = "my-feature")]
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
+    m.insert("my_category.my_builtin", (my_builtin, 2));
+}
+```
+
+Update `Cargo.toml` if adding a new feature flag. Update
+`docs/knowledge/feature-composition.md` with the new flag.
+
+### 5. Add Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_my_builtin_basic() { /* ... */ }
+
+    #[test]
+    fn test_my_builtin_undefined_input() {
+        // Verify Undefined propagation behavior
+    }
+
+    #[test]
+    fn test_my_builtin_type_mismatch() {
+        // Verify returns Undefined, not error
+    }
+
+    #[test]
+    fn test_my_builtin_edge_cases() {
+        // Empty inputs, null, very large values, etc.
+    }
+}
+```
+
+### 6. Verify OPA Conformance
+
+```bash
+# Run conformance tests
+cargo test --test opa --features opa-testutil
+
+# If OPA test data exists for this builtin, verify it passes
+cargo test --test opa --features opa-testutil -- my_builtin
+```
+
+### 7. Update Documentation
+
+- Add the builtin to `docs/builtins.md`
+- If it's complex, consider updating `docs/knowledge/builtin-system.md`
+
+## Checklist
+
+- [ ] Function implemented with correct signature
+- [ ] Returns Undefined for type mismatches (not errors)
+- [ ] Handles Undefined inputs correctly
+- [ ] Registered with correct name and arg count
+- [ ] Feature-gated if needed
+- [ ] Unit tests cover: basic, undefined, type mismatch, edge cases
+- [ ] OPA conformance tests pass
+- [ ] Works in both interpreter and RVM
+- [ ] Documentation updated
+- [ ] Compiles with `--no-default-features` (if not feature-gated)
+
+## Reference
+
+- `docs/knowledge/builtin-system.md` — Full registration architecture
+- `docs/knowledge/value-semantics.md` — Undefined propagation rules
+- `docs/knowledge/feature-composition.md` — Feature flag guidance
+- `src/builtins/` — Existing builtins as examples

--- a/.github/skills/design-alternatives/SKILL.md
+++ b/.github/skills/design-alternatives/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: design-alternatives
+description: >-
+  Explore multiple design alternatives for a feature or change in regorus.
+  Use this skill when asked to consider different approaches, evaluate
+  tradeoffs, compare implementations, or when facing a non-trivial design
+  decision. Generates and evaluates multiple candidates before recommending.
+allowed-tools: shell
+---
+
+# Design Alternatives Skill
+
+When facing a non-trivial design decision in regorus, don't commit to the
+first approach that comes to mind. Generate multiple alternatives, evaluate
+their tradeoffs against regorus's constraints, and recommend the best option.
+
+## Strategy
+
+### Phase 1: Understand the Problem
+
+Before generating alternatives:
+
+1. **Clarify the requirement** — what exactly must this achieve?
+2. **Identify constraints** — which of regorus's constraints apply?
+   - no_std compatibility
+   - 9 FFI binding targets
+   - Dual execution paths (interpreter + RVM)
+   - Feature flag composition
+   - Security-critical correctness
+   - Performance at scale
+3. **Read relevant knowledge files** from `docs/knowledge/`
+4. **Study existing patterns** — how does the codebase solve similar problems?
+
+### Phase 2: Generate Alternatives
+
+Generate **at least 3 meaningfully different approaches**. Don't generate
+trivial variations — each alternative should represent a genuinely different
+design philosophy or tradeoff.
+
+For each alternative, describe:
+- **Approach**: what it does and how
+- **Key design choice**: what makes this different from the others
+
+Push yourself to consider:
+- The obvious approach everyone would try first
+- A simpler approach that sacrifices some capability
+- A more sophisticated approach that handles more edge cases
+- An approach that reuses existing infrastructure differently
+- An approach from a different domain that could apply here
+
+### Phase 3: Evaluate
+
+Evaluate each alternative against these dimensions (weight by relevance
+to the specific problem):
+
+| Dimension | Description |
+|-----------|-------------|
+| **Correctness** | Can this be implemented correctly? How many edge cases? |
+| **Security** | Attack surface? Resource bounds? Panic safety? |
+| **Complexity** | How much code? How hard to understand and maintain? |
+| **Performance** | Runtime cost? Memory cost? Scales with what? |
+| **Compatibility** | Works with no_std? All FFI targets? All feature combos? |
+| **Extensibility** | Easy to extend later? Blocks future plans? |
+| **Testability** | Easy to test? Property-testable? |
+| **Migration cost** | How much existing code must change? |
+| **Risk** | What could go wrong? How bad is the failure mode? |
+
+Be honest about tradeoffs. Every approach has weaknesses — name them
+explicitly rather than advocating for a favorite.
+
+### Phase 4: Recommend
+
+1. **Rank** the alternatives
+2. **Recommend** one with clear reasoning
+3. **Identify risks** in the recommended approach
+4. **Suggest mitigations** for those risks
+5. **Note what to revisit** — decisions that should be reconsidered
+   if assumptions change
+
+If no alternative is clearly best, say so. Present the decision to the
+user with the tradeoffs clearly laid out so they can make an informed choice.
+
+## Example Decision Framework
+
+For a decision like "how should we implement partial evaluation":
+
+**Alternative A: AST-level transformation**
+- Walk AST, evaluate ground subexpressions, leave symbolic ones
+- Simple, reuses parser, but loses RVM optimizations
+
+**Alternative B: RVM-level symbolic execution**
+- Extend registers with symbolic values, execute normally
+- Complex, but preserves all optimizations and is more precise
+
+**Alternative C: Hybrid — compile then reduce**
+- Compile to RVM, then do a simplification pass on bytecode
+- Medium complexity, preserves compilation optimizations
+
+Evaluate each against correctness (Undefined propagation!), complexity,
+performance, and extensibility. The right answer depends on which
+constraints matter most for this specific decision.
+
+## Anti-Patterns
+
+- **Don't generate strawmen** — every alternative should be genuinely viable
+- **Don't evaluate only on your preferred dimension** — consider all
+- **Don't hide tradeoffs** — if an approach is risky, say so clearly
+- **Don't over-engineer** — sometimes the simplest approach is best
+- **Don't ignore existing patterns** — the codebase has established idioms
+
+## Reference
+
+All knowledge files in `docs/knowledge/` are potentially relevant —
+choose based on the subsystem being designed for. Key files:
+
+- `docs/knowledge/rvm-architecture.md` — RVM design constraints
+- `docs/knowledge/ffi-boundary.md` — FFI compatibility requirements
+- `docs/knowledge/feature-composition.md` — Feature flag constraints
+- `docs/knowledge/value-semantics.md` — Value type constraints
+- `docs/knowledge/language-extension-guide.md` — Extensibility patterns
+- `docs/knowledge/causality-and-partial-eval.md` — Future architecture vision

--- a/.github/skills/opa-conformance/SKILL.md
+++ b/.github/skills/opa-conformance/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: opa-conformance
+description: >-
+  Check OPA conformance for regorus changes. Use this skill when modifying
+  Rego evaluation, builtins, or anything that could affect OPA compatibility.
+  Runs conformance tests and analyzes failures.
+allowed-tools: shell
+---
+
+# OPA Conformance Skill
+
+regorus aims for high conformance with the Open Policy Agent (OPA) reference
+implementation. This skill helps verify that changes don't break conformance
+and diagnose any failures.
+
+## When to Use
+
+- Modifying Rego evaluation (interpreter or RVM compiler)
+- Adding or changing builtin functions
+- Changing the Value type or its operations
+- Modifying the parser or scheduler
+- Any change where you're unsure if it affects Rego semantics
+
+## Running Conformance Tests
+
+```bash
+# Full OPA conformance suite
+cargo test --test opa --features opa-testutil
+
+# Run with verbose output to see which tests pass/fail
+cargo test --test opa --features opa-testutil -- --nocapture
+
+# Run a specific conformance test category
+cargo test --test opa --features opa-testutil -- test_name_pattern
+```
+
+## Analyzing Failures
+
+When conformance tests fail:
+
+1. **Read the test case** — OPA conformance tests are in `tests/opa/` and
+   follow a standard structure: input, data, policy, expected result
+2. **Identify the Rego feature** — which language feature does the failing
+   test exercise? (comprehensions, `with`, negation, builtins, etc.)
+3. **Check both execution paths** — run the failing test against both the
+   interpreter and RVM to see if the failure is path-specific
+4. **Compare with OPA spec** — the expected result comes from the OPA
+   reference implementation. Understand why OPA produces that result.
+5. **Check Undefined propagation** — the most common conformance failure
+   is incorrect Undefined handling. Review `docs/knowledge/value-semantics.md`.
+
+## Known Non-Conformance
+
+Some OPA features are intentionally not supported or have known gaps.
+Before investigating a failure, check if it's in a known category:
+
+- Check `tests/` for any skip lists or known-failure annotations
+- Check GitHub issues for tracked conformance gaps
+- Some builtins may be feature-gated — ensure the right features are enabled
+
+## After Fixing
+
+After fixing a conformance issue:
+
+1. Run the full conformance suite to ensure no regressions
+2. Run `cargo test` for general test suite
+3. Verify the fix works in both interpreter and RVM paths
+4. Update `docs/knowledge/` if the fix reveals a subtle semantic rule
+
+## Reference
+
+- `docs/knowledge/rego-semantics.md` — Rego evaluation model
+- `docs/knowledge/value-semantics.md` — Value type and Undefined
+- `docs/knowledge/builtin-system.md` — Builtin registration and conformance
+- `docs/knowledge/interpreter-architecture.md` — Interpreter details
+- `docs/knowledge/rego-compiler.md` — RVM compiler details

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: security-review
+description: >-
+  Security-focused review for regorus changes. Use this skill when asked to
+  do a security review, threat analysis, or when reviewing changes to FFI
+  boundaries, resource limits, policy evaluation, or dependency updates.
+allowed-tools: shell
+---
+
+# Security Review Skill
+
+regorus is a security-critical policy evaluation engine. Policy evaluation
+bugs can lead to incorrect access control decisions at Azure scale. This skill
+provides a security-focused review lens.
+
+## Threat Model
+
+regorus evaluates **untrusted policies and inputs** provided by external users.
+The engine must:
+
+1. **Produce correct results** — a wrong allow/deny is a security bug
+2. **Not crash** — panics in FFI contexts poison the engine permanently
+3. **Bound resource usage** — adversarial inputs must not cause DoS
+4. **Maintain isolation** — evaluation of one policy must not affect another
+5. **Protect the host** — no arbitrary code execution, file access, or network access
+
+## Review Approach
+
+Think adversarially. For each change, ask:
+
+### Policy Evaluation Correctness
+
+- Could this change cause a policy to evaluate to a different result?
+- If the result changes, is that the correct behavior per specification?
+- What happens with edge-case inputs: empty, null, very large, deeply nested?
+- What happens when values are Undefined? (`not Undefined = true`)
+- Are default rules affected?
+
+### Resource Exhaustion
+
+- Does this introduce unbounded iteration (no instruction budget check)?
+- Does this allocate memory proportional to untrusted input size?
+- Does this add recursion without depth bounds?
+- Can an adversarial policy trigger O(n²) or worse behavior?
+- RVM instruction budget is 25,000 — does this change affect instruction
+  count significantly for common policies?
+
+### Panic Safety
+
+- Can this code path panic? (`.unwrap()`, `.expect()`, index `[i]`,
+  integer overflow via `as` casts, slice out of bounds)
+- Is this reachable from FFI? (If so, panic = permanent engine poisoning)
+- Are all match arms exhaustive?
+- Are arithmetic operations checked? (`checked_add`, `saturating_mul`, etc.)
+
+### FFI Boundary
+
+If the change touches public API or FFI:
+- Does the handle pattern remain safe? (`Box::into_raw` / `Box::from_raw`)
+- Is `with_unwind_guard()` used for panic containment?
+- Do all 9 binding languages handle the change correctly?
+- Are error codes and status values consistent?
+- Could a binding language misuse the new API in a way that causes UB?
+
+### Supply Chain
+
+If dependencies change:
+- Is the new dependency necessary?
+- Does it have known vulnerabilities? (`cargo audit`)
+- Does it use `unsafe`? How much?
+- Is it maintained? How many maintainers?
+- Does it support `no_std` with `default-features = false`?
+- Could it be replaced with a smaller, more focused crate?
+
+Run: `cargo audit` and `cargo deny check` after dependency changes.
+
+### Feature Flag Safety
+
+- Does this compile with `--all-features`?
+- Does this compile with `--no-default-features`?
+- Does the `arc` feature (Rc→Arc) work correctly with this change?
+- Are `#[cfg(...)]` guards correct and complete?
+
+## Automated Security Checks
+
+```bash
+# Dependency audit
+cargo audit
+
+# Dependency policy check
+cargo deny check
+
+# Clippy with all features (catches unsafe patterns)
+cargo clippy --all-features -- -D warnings
+
+# Clippy with no features (no_std safety)
+cargo clippy --no-default-features -- -D warnings
+
+# Miri for memory safety (if nightly available)
+cargo +nightly miri test
+```
+
+## Severity Assessment
+
+For each finding, assess:
+
+- **Impact**: what's the worst case if exploited?
+- **Exploitability**: can an external user trigger this?
+- **Scope**: how many deployments are affected?
+
+In regorus, most evaluation bugs are high-impact because they affect
+policy decisions across all deployments using the engine.
+
+## Reference
+
+- `docs/knowledge/policy-evaluation-security.md` — DoS protection, limits
+- `docs/knowledge/ffi-boundary.md` — Handle pattern, panic containment
+- `docs/knowledge/feature-composition.md` — Feature flag interactions
+- `docs/knowledge/value-semantics.md` — Undefined propagation (security-relevant)

--- a/.github/skills/thorough-review/SKILL.md
+++ b/.github/skills/thorough-review/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: thorough-review
+description: >-
+  Multi-agent thorough code review for regorus. Use this skill when asked to
+  do a thorough review, deep review, or comprehensive review of code changes.
+  Orchestrates parallel focused reviewers with adversarial defense filtering.
+allowed-tools: shell
+---
+
+# Thorough Review Skill
+
+You orchestrate a deep code review of regorus changes by launching parallel
+focused reviewers, each with a different focus area. regorus is a
+security-critical policy engine — behavioral bugs are security bugs.
+
+**Do not** run cargo, clippy, tests, or build commands. This skill is
+diff-review only.
+
+## Step 1: Get the Diff
+
+```bash
+git diff $(git merge-base origin/main HEAD)..HEAD --stat
+git diff $(git merge-base origin/main HEAD)..HEAD
+```
+
+If that fails, try `git diff main` then `git diff HEAD~1`.
+If the diff is large (>500 lines), get the stat first and focus reviewers on
+relevant files rather than the full diff.
+
+## Step 2: Select Focus Areas
+
+**Always run these 3:**
+
+| # | Focus | Description |
+|---|-------|-------------|
+| 1 | Semantic Correctness | Wrong allow/deny, Undefined propagation, three-valued logic, `with` scoping, dual-path consistency. For non-Rego languages: language-specific evaluation semantics (effects, aliases, conditions). |
+| 2 | Panic Safety | unwrap/indexing/overflow bypasses that deny lints can't catch statically, logic-dependent panic paths, fallible conversions without error handling. |
+| 3 | Resource Exhaustion | Unbounded loops, recursion, allocation growth, complexity bombs on untrusted input, missing limit checks. |
+
+**Add these when triggered by changed files:**
+
+| # | Focus | Description | Triggers |
+|---|-------|-------------|----------|
+| 4 | API & FFI | Semver breaks, panic containment across 9 bindings, handle safety, null checks, UTF-8/ABI. | `src/engine.rs`, `bindings/**`, public type changes |
+| 5 | Feature Composition | `#[cfg]` correctness, no_std leakage, missing feature gates, non-default build combos. | `Cargo.toml`, files with `#[cfg(feature` |
+| 6 | Input & Encoding | Parser limits, injection, malformed UTF-8, path traversal, bundle decoding. | `src/lexer*`, `src/parser*`, `src/builtins/**` |
+| 7 | Supply Chain & CI | Unpinned actions, expression injection, new deps without audit, lockfile drift. | `.github/**`, `Cargo.toml` deps, lockfiles |
+
+Look at the diff's file list. Activate triggered areas whose patterns match.
+In `thorough` mode (default), activate ALL areas regardless of triggers.
+
+## Step 3: Launch Parallel Reviewers
+
+For each selected focus area, launch a **task agent** (agent_type: "rubber-duck")
+in background mode with this prompt (fill in the blanks):
+
+> Review this regorus diff for **{focus area name}** issues:
+> **{one-line description from table above}**
+>
+> Context: regorus is a security-critical policy evaluation engine (Rego + Azure
+> Policy). `#![no_std]`, `#![forbid(unsafe_code)]`, 80+ deny lints, 9 FFI targets,
+> dual execution paths (interpreter + RVM).
+>
+> Relevant knowledge: `docs/knowledge/{relevant file}` — read it if you need
+> domain-specific invariants.
+>
+> Here are the changed files:
+> {file list from --stat}
+>
+> Here is the diff (or relevant hunks if large):
+> ```
+> {diff content — for large diffs, include only hunks relevant to this focus}
+> ```
+>
+> Find real bugs with code evidence. No vague concerns. If you find nothing
+> noteworthy, say so.
+
+For large diffs (>500 lines), split the diff by relevance — each reviewer gets
+only the hunks/files relevant to their focus area rather than the full diff.
+
+**Knowledge file mapping** (suggest the most relevant one per focus):
+- Semantic Correctness → `rego-semantics.md`, `value-semantics.md`, `azure-policy-language.md`
+- Panic Safety → `ffi-boundary.md`, `error-handling-migration.md`
+- Resource Exhaustion → `policy-evaluation-security.md`
+- API & FFI → `ffi-boundary.md`, `engine-api.md`
+- Feature Composition → `feature-composition.md`
+- Input & Encoding → `policy-evaluation-security.md`, `compilation-pipeline.md`
+- Supply Chain & CI → `workflow-security.md`
+
+Launch ALL reviewers in parallel using the task tool (rubber-duck agent type).
+
+## Step 4: Defense
+
+After all reviewers report back, challenge **Critical and High** findings:
+
+For each Critical/High finding, ask yourself:
+- Is the code path actually reachable with untrusted input?
+- Does an existing guard (limit check, type constraint, deny lint) already prevent this?
+- Is the "fix" obvious, or is this a design-level issue?
+
+Downgrade or drop findings that fail this check. When downgrading or dropping,
+name the exact guard or constraint that makes the issue unreachable or contained.
+Keep findings that survive.
+
+## Step 5: Report
+
+Present findings sorted by severity (Critical → High → Medium → Low):
+
+For each finding:
+- **Severity**: Critical / High / Medium / Low
+- **Focus area**: which reviewer found it
+- **Location**: file:line
+- **Issue**: one-sentence summary
+- **Evidence**: the specific code and why it's wrong
+- **Suggestion**: how to fix (if obvious)
+
+End with a summary: X findings (N critical, N high, N medium, N low).
+
+## Modes
+
+- **`thorough`** (default): All 7 focus areas, full defense phase
+- **`quick`**: Only the 3 always-run areas, skip defense for medium/low findings

--- a/.github/skills/verification/SKILL.md
+++ b/.github/skills/verification/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: verification
+description: >-
+  Formal verification and memory safety verification for regorus. Use this
+  skill when asked about Miri, formal verification, Z3, Verus, property
+  testing, or when verifying safety properties of regorus code.
+allowed-tools: shell
+---
+
+# Verification Skill
+
+regorus uses multiple verification approaches to ensure correctness and
+memory safety. This skill guides verification efforts.
+
+## Verification Tiers
+
+### Tier 1: Miri (Active — in CI)
+
+Miri detects undefined behavior in unsafe code, memory leaks, and
+concurrency bugs. regorus runs Miri in CI.
+
+```bash
+# Run Miri on the test suite
+cargo +nightly miri test
+
+# Run Miri on specific tests
+cargo +nightly miri test -- test_name
+
+# Run with stricter checks
+MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test
+```
+
+**What Miri catches:**
+- Use-after-free, double-free
+- Out-of-bounds memory access
+- Uninitialized memory reads
+- Data races (with `-Zmiri-check-stacked-borrows`)
+- Memory leaks
+
+**regorus context:** The core crate is `#![forbid(unsafe_code)]`, so Miri
+is most relevant for FFI binding crates (`bindings/ffi/`) where unsafe is
+allowed. Also useful for verifying `Rc::make_mut()` patterns.
+
+### Tier 2: Property Testing (Recommended)
+
+Use `proptest` or `quickcheck` to test properties that must hold for all
+inputs:
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn value_roundtrip(v in arb_value()) {
+        let json = v.to_json_str();
+        let parsed = Value::from_json_str(&json)?;
+        prop_assert_eq!(v, parsed);
+    }
+
+    #[test]
+    fn eval_deterministic(policy in arb_policy(), input in arb_input()) {
+        let r1 = engine.eval(&policy, &input)?;
+        let r2 = engine.eval(&policy, &input)?;
+        prop_assert_eq!(r1, r2);
+    }
+}
+```
+
+**Properties worth testing in regorus:**
+- Value serialization round-trips
+- Evaluation determinism (same input → same output)
+- Interpreter/RVM equivalence (both paths produce same result)
+- Undefined propagation consistency
+- Resource limit enforcement (instruction budget halts execution)
+- RVM program serialization round-trips
+
+### Tier 3: Z3 / SMT Solving (Planned)
+
+For verifying policy properties symbolically:
+
+- **Policy satisfiability**: is there any input that satisfies this policy?
+- **Policy equivalence**: do two policies produce the same result for all inputs?
+- **Policy subsumption**: does policy A imply policy B?
+- **Unreachable rules**: are there rules that can never fire?
+
+This connects to the partial evaluation vision in
+`docs/knowledge/causality-and-partial-eval.md`.
+
+### Tier 4: Verus (Planned)
+
+Verus enables verified Rust — proving properties about Rust code at
+compile time. Potential targets in regorus:
+
+- **Value type invariants**: prove that Value operations preserve type safety
+- **RVM instruction safety**: prove that well-formed programs cannot cause
+  register overflow or invalid memory access
+- **Scheduler correctness**: prove that topological sort produces valid order
+- **Resource limit enforcement**: prove that instruction budget is checked
+
+## Verification Strategies by Subsystem
+
+### Value Type (`src/value.rs`)
+- Property test: all operations handle Undefined correctly
+- Property test: comparison is total ordering
+- Property test: serialization round-trips for all Value variants
+- Miri: Rc::make_mut patterns don't alias
+
+### RVM (`src/rvm/`)
+- Property test: program serialization round-trips
+- Property test: instruction budget halts execution within bounds
+- Property test: register allocation stays within frame bounds
+- Miri: frame stack operations are memory-safe
+
+### FFI (`bindings/ffi/`)
+- Miri: handle create/destroy cycles don't leak
+- Miri: panic containment doesn't cause UB
+- Property test: poisoned engine rejects all operations
+
+### Builtins (`src/builtins/`)
+- Property test: builtins return Undefined (not error) for type mismatches
+- Property test: time parsing matches OPA reference for valid inputs
+- Property test: string operations handle UTF-8 edge cases
+
+## Running Verification
+
+```bash
+# Tier 1: Miri
+cargo +nightly miri test
+
+# Tier 2: Property tests (if added)
+cargo test --test prop_tests
+
+# Full verification suite
+cargo +nightly miri test && cargo test && cargo test --test opa --features opa-testutil
+```
+
+## Reference
+
+- `docs/knowledge/policy-evaluation-security.md` — Security properties to verify
+- `docs/knowledge/value-semantics.md` — Value invariants
+- `docs/knowledge/rvm-architecture.md` — RVM safety properties
+- `docs/knowledge/ffi-boundary.md` — FFI safety requirements
+- `docs/knowledge/causality-and-partial-eval.md` — Symbolic analysis vision

--- a/docs/knowledge/azure-policy-aliases.md
+++ b/docs/knowledge/azure-policy-aliases.md
@@ -1,0 +1,287 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Azure Policy Aliases and Normalization
+
+Deep knowledge about the Azure Policy alias system and ARM resource
+normalization. Read this before modifying alias resolution, the normalizer,
+or the denormalizer.
+
+See also `azure-policy-language.md` for the overall Azure Policy compilation
+pipeline.
+
+## What Aliases Are
+
+Azure Policy uses "aliases" to refer to Azure resource properties in a
+provider-independent way:
+
+```
+Full alias:  Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly
+Short name:  supportsHttpsTrafficOnly
+ARM path:    properties.supportsHttpsTrafficOnly
+```
+
+The alias system bridges between:
+- **Policy authors** — who write conditions using alias paths
+- **ARM resources** — which have nested JSON structures with varying casing
+
+## Alias Registry
+
+### Loading Sources
+
+**Control-plane aliases** — loaded from Azure provider metadata:
+```
+GET /providers?$expand=resourceTypes/aliases
+```
+Produces `ProviderAliases` with resource type → alias mappings.
+
+**Data-plane aliases** — loaded from data policy manifests for `.Data`
+namespaces (e.g., `Microsoft.KeyVault.Data/vaults/secrets`).
+
+### Registry Structure
+
+```rust
+struct AliasRegistry {
+    // Maps full alias name → alias metadata
+    aliases: BTreeMap<String, AliasInfo>,
+    // Maps resource type → list of aliases
+    resource_type_aliases: BTreeMap<String, Vec<String>>,
+}
+```
+
+The registry provides:
+- Alias path segments (for navigating ARM JSON)
+- Alias type metadata (string, array, object, etc.)
+- Default path mappings when aliases are absent
+
+## Normalization Pipeline
+
+The normalizer transforms ARM resource JSON into a flat structure that
+the policy compiler can evaluate directly.
+
+### Input: ARM Resource JSON
+
+```json
+{
+  "type": "Microsoft.Storage/storageAccounts",
+  "id": "/subscriptions/.../storageAccounts/myaccount",
+  "name": "myaccount",
+  "location": "eastus",
+  "properties": {
+    "supportsHttpsTrafficOnly": true,
+    "networkAcls": {
+      "defaultAction": "Deny",
+      "virtualNetworkRules": [
+        { "id": "/subscriptions/.../subnets/default" }
+      ]
+    }
+  }
+}
+```
+
+### Output: Normalized Resource
+
+```json
+{
+  "type": "microsoft.storage/storageaccounts",
+  "id": "/subscriptions/.../storageAccounts/myaccount",
+  "name": "myaccount",
+  "location": "eastus",
+  "supportshttpstrafficonly": true,
+  "networkacls.defaultaction": "Deny",
+  "networkacls.virtualnetworkrules": [
+    { "id": "/subscriptions/.../subnets/default" }
+  ]
+}
+```
+
+### Normalization Steps
+
+1. **Copy root fields** (lowercased): `type`, `id`, `kind`, `name`,
+   `location`, `identity`, `zones`, `sku`, `plan`, `tags`
+
+2. **Merge properties** — contents of `properties` are merged into the
+   result at the top level
+
+3. **Apply alias path resolution**:
+   - Each alias has a path (e.g., `properties.networkAcls.defaultAction`)
+   - The normalizer navigates the ARM JSON using path segments
+   - The extracted value is placed at the alias short name (lowercased)
+
+4. **Handle sub-resources** — sub-resource types (e.g., extensions on VMs)
+   are extracted from arrays and normalized separately
+
+5. **Array element handling** — `[*]` in alias paths triggers iteration
+   over array elements; each element is normalized independently
+
+6. **Case folding** — all property names are lowercased for
+   case-insensitive matching (Azure ARM is case-insensitive)
+
+### Key Complexity: Case Preservation
+
+ARM JSON casing is preserved through normalization and denormalization.
+The normalizer records original casing to enable round-trip fidelity.
+This matters for Modify/Append effects that construct output JSON.
+
+## Denormalization
+
+The denormalizer converts flat normalized paths back to nested ARM JSON
+structure. This is needed for:
+- **Modify effect** — construct the resource patch to apply
+- **Append effect** — construct fields to add to the resource
+
+### Denormalization Challenge
+
+Given a flat path like `networkacls.defaultaction = "Allow"`, the
+denormalizer must reconstruct:
+
+```json
+{
+  "properties": {
+    "networkAcls": {
+      "defaultAction": "Allow"
+    }
+  }
+}
+```
+
+This requires knowing:
+- Where `properties` nesting begins (alias metadata)
+- Original casing of each path segment
+- Whether intermediate nodes are objects or arrays
+
+## Compiler Integration
+
+### Alias Map
+
+The compiler receives an alias map: `BTreeMap<String, String>` mapping
+alias short names to full ARM paths. This is populated from the
+`AliasRegistry` for the specific resource type being evaluated.
+
+### Field Compilation
+
+When compiling a `field` condition:
+
+```json
+{ "field": "supportsHttpsTrafficOnly", "equals": true }
+```
+
+1. Look up field name in alias map
+2. If found: compile as property access on normalized input
+3. If dynamic (`[concat(...)]`): compile ARM expression, use result as key
+4. Emit `Index`/`IndexLiteral`/`ChainedIndex` instructions
+
+### Metadata Accumulation
+
+During compilation, the compiler tracks:
+- `observed_aliases` — all alias names referenced
+- `observed_field_kinds` — static fields, dynamic fields, `[*]` wildcards
+- `observed_resource_types` — resource types from field conditions
+- `observed_has_dynamic_fields` — whether ARM expressions appear as fields
+
+This metadata supports policy analysis and optimization.
+
+## Wildcard Semantics
+
+### Unbound `[*]` (outside count)
+
+```json
+{ "field": "securityRules[*].destinationPortRange", "equals": "443" }
+```
+
+Implicit `allOf` — **every** element must match. The compiler generates
+a `LoopStart { mode: Every }` instruction.
+
+### Bound `[*]` (inside count)
+
+```json
+{
+  "count": {
+    "field": "securityRules[*]",
+    "where": { "field": "securityRules[*].destinationPortRange", "equals": "443" }
+  },
+  "greaterOrEquals": 1
+}
+```
+
+Iteration with counting — each element is tested, matching ones are
+counted. The compiler generates `LoopStart { mode: Count }`.
+
+### Multi-level Wildcards
+
+```json
+{ "field": "outer[*].inner[*].value" }
+```
+
+Nested loops: outer levels use `ForEach`, innermost carries the semantic
+operator. The compiler maintains a binding stack to track scope.
+
+## `current()` Function
+
+Inside `count.where` blocks, `current()` refers to the current iteration
+element:
+
+```json
+{
+  "count": {
+    "value": "[parameters('items')]",
+    "name": "item",
+    "where": {
+      "value": "[current('item').status]",
+      "equals": "active"
+    }
+  }
+}
+```
+
+The compiler binds the loop variable and makes it accessible via
+`current()` calls in ARM template expressions.
+
+## Existence vs Null
+
+Azure Policy distinguishes between missing fields and null values:
+
+- **Missing field** → `Undefined` in regorus Value system
+- **Null field** → `Value::Null`
+
+For most operators, the compiler emits `CoalesceUndefinedToNull` to
+treat missing as null. The `exists` operator is the exception — it
+specifically tests for field presence:
+
+```json
+{ "field": "optionalProperty", "exists": true }   // Field must be present
+{ "field": "optionalProperty", "exists": false }  // Field must be absent
+```
+
+## Key Invariants
+
+1. **Normalization before compilation** — aliases are resolved during
+   normalization, not at compile time or runtime
+
+2. **Case-insensitive everywhere** — all field name comparisons use
+   lowercased strings
+
+3. **`[*]` context matters** — same syntax has different semantics
+   inside vs outside `count` expressions
+
+4. **Round-trip fidelity** — normalize → denormalize must preserve
+   original ARM JSON casing for Modify/Append effects
+
+5. **Missing = null (mostly)** — `CoalesceUndefinedToNull` is the
+   default; `exists` is the exception
+
+## Common Pitfalls
+
+1. **Alias path segments** — paths like `properties.a.b` must be split
+   correctly. Dots in property names (rare but possible) need escaping.
+
+2. **Sub-resource normalization** — sub-resources have their own type
+   and their own alias set. Don't normalize with parent's aliases.
+
+3. **Array vs scalar** — some aliases point to arrays, others to scalars.
+   The `[*]` wildcard only works on arrays. Applying it to a scalar
+   is a compile-time error.
+
+4. **Dynamic field resolution order** — ARM template expressions in
+   field positions are evaluated at runtime. The alias map must be
+   available at runtime for dynamic alias resolution.

--- a/docs/knowledge/azure-policy-language.md
+++ b/docs/knowledge/azure-policy-language.md
@@ -1,0 +1,203 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Azure Policy Language
+
+Deep knowledge about the Azure Policy language extension in
+`src/languages/azure_policy/`. Read this before modifying Azure Policy
+parsing, compilation, or evaluation.
+
+## How Azure Policy Differs from Rego
+
+| Aspect | Azure Policy | Rego |
+|--------|--------------|------|
+| **Syntax** | JSON-based declarative constraints | Prolog-like logic language |
+| **Compilation** | JSON → AST → RVM bytecode | Source → AST → RVM bytecode |
+| **Logic model** | `allOf`/`anyOf`/`not` combinators | Set comprehensions, rules |
+| **Effects** | Policy decision directives (Deny, Audit, Modify, ...) | Returns values |
+| **Templating** | ARM template expressions `[concat(...)]` | No templating |
+| **Field access** | Direct properties + aliases for resource types | Dot-notation queries |
+
+Despite these differences, Azure Policy compiles to the **same RVM bytecode**
+as Rego. The shared VM executes both languages.
+
+## Directory Structure
+
+```
+src/languages/azure_policy/
+  mod.rs                    Module root
+  parser/                   JSON → PolicyRule AST (6 files)
+  compiler/                 AST → RVM Program (14 files)
+  ast/                      Span-annotated AST types
+  aliases/                  ARM resource alias normalization
+    normalizer/             ARM JSON → flat alias paths
+    denormalizer/           Flat paths → ARM JSON structure
+  expr.rs                   ARM template expression sub-parser
+  strings/                  Case folding, key normalization
+```
+
+## AST Types
+
+### Policy Rule Structure
+
+```
+PolicyRule
+  ├── condition: Constraint    // "if" clause
+  └── then_block: ThenBlock    // "then" clause with effect
+```
+
+### Constraint Hierarchy
+
+```rust
+enum Constraint {
+    AllOf { constraints: Vec<Constraint> },   // AND — all must match
+    AnyOf { constraints: Vec<Constraint> },   // OR — any must match
+    Not { constraint: Box<Constraint> },      // Negation
+    Condition(Box<Condition>),                // Leaf condition
+}
+
+struct Condition {
+    lhs: Lhs,              // What to evaluate (Field, Value, or Count)
+    operator: OperatorNode, // How to compare (19 operators)
+    rhs: ValueOrExpr,       // What to compare against
+}
+```
+
+### 19 Operators
+
+Contains, ContainsKey, Equals, Greater, GreaterOrEquals, Exists, In, Less,
+LessOrEquals, Like, Match, MatchInsensitively, NotContains, NotContainsKey,
+NotEquals, NotIn, NotLike, NotMatch, NotMatchInsensitively.
+
+### Effects
+
+```rust
+enum EffectKind {
+    Deny, Audit, Append, AuditIfNotExists, DeployIfNotExists,
+    Disabled, Modify, DenyAction, Manual, Other,
+}
+```
+
+**Note:** Effect compilation is not yet fully implemented — the compiler
+has stubs for effect handling.
+
+## Compilation to RVM
+
+Azure Policy compiles directly to RVM bytecode through a dedicated compiler:
+
+```rust
+pub fn compile_policy_rule(rule: &PolicyRule) -> Result<Rc<Program>>
+pub fn compile_policy_definition(defn: &PolicyDefinition) -> Result<Rc<Program>>
+pub fn compile_policy_definition_with_aliases(rule, alias_map, modifiable) -> Result<Rc<Program>>
+```
+
+The compiler:
+1. Parses JSON → `PolicyRule` AST
+2. Compiles constraints to RVM instructions (shared VM)
+3. Populates metadata (language annotation "azure_policy", effect info)
+4. Resolves parameter defaults
+5. Optionally resolves aliases
+
+### Compiler State
+
+```rust
+struct Compiler {
+    program: Program,                    // Shared RVM program being built
+    register_counter: u8,               // Register allocation
+    alias_map: BTreeMap<String, String>,// Alias resolution
+    parameter_defaults: Option<Value>,  // Default parameter values
+    cached_input_reg: Option<u8>,       // Cached LoadInput register
+    cached_context_reg: Option<u8>,     // Cached LoadContext register
+}
+```
+
+## Alias System
+
+Azure Policy uses "aliases" to refer to resource properties in a normalized
+way. The alias system has two phases:
+
+### Normalizer
+
+Converts ARM JSON resource representations to flat structures with alias
+paths. Handles:
+- Nested resource properties
+- Sub-resource types (e.g., `Microsoft.Compute/virtualMachines/extensions`)
+- Array element access
+- Case-insensitive property matching
+
+### Denormalizer
+
+Converts flat alias paths back to ARM JSON structure. This is needed for
+Modify/Append effects that need to construct resource representations.
+
+**Key complexity**: Casing must survive round-trip. ARM JSON casing is
+preserved through normalization and denormalization.
+
+## ARM Template Expressions
+
+Azure Policy conditions can contain ARM template expressions:
+
+```json
+{
+    "field": "[concat(field('Microsoft.Storage/storageAccounts/name'), '/default')]",
+    "equals": "[parameters('storageName')]"
+}
+```
+
+The expression parser (`expr.rs`) handles:
+- Recursive descent parsing (`.`, `()`, `[]` operators)
+- Unknown symbols enabled in lexer mode
+- 65,536 character column limit for deeply nested expressions
+- Functions: `concat()`, `field()`, `parameters()`, etc.
+
+## Count Expressions
+
+Azure Policy supports counting with optional `where` clauses:
+
+```json
+{
+    "count": {
+        "field": "Microsoft.Network/networkSecurityGroups/securityRules[*]",
+        "where": { "field": "...", "equals": "..." }
+    },
+    "greater": 0
+}
+```
+
+The compiler handles count with existence-pattern optimization — common
+patterns like "count > 0" can be compiled as existence checks.
+
+## Wildcard Handling
+
+The `[*]` wildcard in field references creates implicit iteration:
+
+```json
+{ "field": "Microsoft.Network/securityRules[*].destinationPortRange" }
+```
+
+When a wildcard is unbound, it creates an implicit `allOf` — the condition
+must hold for ALL elements. The compiler generates appropriate iteration
+code in the RVM.
+
+## Integration Points
+
+Azure Policy integrates with the shared infrastructure:
+- **RVM Program**: compiled output is the same `Program` struct as Rego
+- **Value type**: evaluation uses the same `Value` enum
+- **Engine**: accessible via `Engine::compile_for_target()` when the
+  `azure_policy` feature is enabled
+- **CompiledPolicy**: wraps the RVM program with metadata
+
+## Key Invariants
+
+1. **Case-insensitive matching** — Azure Policy field names are
+   case-insensitive. All comparisons must use case-folded strings.
+
+2. **Alias resolution order** — aliases must be resolved before compilation.
+   Missing aliases produce compile-time errors, not runtime errors.
+
+3. **Wildcard semantics** — `[*]` is implicitly "for all" unless inside a
+   count expression where it becomes "for each".
+
+4. **Effect metadata** — the compiled program must carry effect information
+   in metadata, not in the instruction stream.

--- a/docs/knowledge/azure-rbac-language.md
+++ b/docs/knowledge/azure-rbac-language.md
@@ -1,0 +1,154 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Azure RBAC Language
+
+Deep knowledge about the Azure RBAC condition language extension in
+`src/languages/azure_rbac/`. Read this before modifying RBAC evaluation.
+
+## How RBAC Differs from Rego and Azure Policy
+
+| Aspect | Azure RBAC | Azure Policy | Rego |
+|--------|-----------|-------------|------|
+| **Purpose** | Access control conditions | Resource compliance | General policy |
+| **Execution** | Direct interpretation | RVM compilation | RVM or interpreter |
+| **Syntax** | Condition expression strings | JSON constraints | Rego source |
+| **Logic** | AND/OR/NOT + quantifiers | allOf/anyOf/not | Rules + comprehensions |
+| **Builtins** | 40+ ABAC functions | 19 operators | 100+ OPA builtins |
+
+**Key difference**: RBAC uses **direct interpretation** (no RVM compilation).
+It has its own `ConditionInterpreter` that evaluates condition strings directly.
+
+## Directory Structure
+
+```
+src/languages/azure_rbac/
+  mod.rs              Module root
+  interpreter.rs      Direct evaluation engine (66 lines)
+  ast/                Expression types (8 files)
+    expr.rs           ConditionExpr enum — 15+ variants
+    context.rs        EvaluationContext (Principal, Resource, Request, Environment)
+    operators.rs      Operator definitions
+    literals.rs       Literal types (string, number, bool, datetime, time, set, list)
+    references.rs     Attribute references
+    spans.rs          Source location tracking
+  parser/             Condition string → AST (3 files)
+  builtins/           40+ ABAC condition functions (14 files)
+  test_cases/         40+ YAML test files
+```
+
+## Evaluation Context
+
+RBAC evaluation happens against a rich context:
+
+```rust
+struct EvaluationContext {
+    principal: Principal,           // Who is accessing
+    resource: Resource,             // What is being accessed
+    request: RequestContext,        // What action is requested
+    environment: EnvironmentContext, // When/where (time, network)
+    action: Option<String>,         // Control-plane action
+    suboperation: Option<String>,   // Sub-operation identifier
+}
+
+struct Principal {
+    id: String,
+    principal_type: PrincipalType,  // User, Group, ServicePrincipal, MSI
+    custom_security_attributes: Value,
+}
+
+struct Resource {
+    id: String,
+    resource_type: String,
+    scope: String,
+    attributes: Value,
+}
+```
+
+## Expression Types
+
+The RBAC AST represents condition expressions:
+
+```rust
+enum ConditionExpr {
+    Logical(LogicalExpression),           // AND/OR
+    Unary(UnaryExpression),              // NOT, exists, notExists
+    Binary(BinaryExpression),            // Operator comparisons
+    FunctionCall(FunctionCallExpression), // ToLower, Substring, etc.
+    AttributeReference(AttributeReference),  // principal.id, resource.attributes.env
+    ArrayExpression(ArrayExpression),     // ANY/ALL quantifiers
+    Identifier(IdentifierExpression),
+    VariableReference(VariableReference), // Loop variables
+    PropertyAccess(PropertyAccessExpression),
+    // Literals: String, Number, Bool, Null, DateTime, Time, Set, List
+}
+```
+
+## Condition Interpreter
+
+The interpreter evaluates conditions directly (no compilation step):
+
+```rust
+struct ConditionInterpreter<'a> {
+    context: &'a EvaluationContext,
+}
+
+impl ConditionInterpreter {
+    fn evaluate_str(&self, condition: &str) -> Result<bool>
+    fn evaluate_condition_expression(&self, cond: &ConditionExpression) -> Result<bool>
+    fn evaluate_bool(&self, expr: &ConditionExpr) -> Result<bool>
+    fn evaluate_value(&self, expr: &ConditionExpr) -> Result<Value>
+}
+```
+
+### Evaluation Flow
+
+1. Parse condition string → `ConditionExpression` with `ConditionExpr` AST
+2. Recursively evaluate:
+   - **Logical**: AND/OR with short-circuit evaluation
+   - **Unary**: NOT, exists (check if attribute is present), notExists
+   - **Binary**: delegate to `RbacBuiltinEvaluator` for comparison
+   - **Function calls**: evaluate with built-in RBAC functions
+   - **Array expressions**: ANY/ALL quantifiers over collections
+   - **Attribute references**: resolve from evaluation context
+
+## RBAC Builtins (40+ functions)
+
+Organized by category:
+
+| Category | Functions |
+|----------|-----------|
+| **Strings** | StringEquals, StringEqualsIgnoreCase, StringLike, StringMatches, StringNotEquals, ... |
+| **Numbers** | NumericEquals, NumericGreaterThan, NumericInRange, ... |
+| **Booleans** | BoolEquals, BoolNotEquals |
+| **GUIDs** | GuidEquals, GuidNotEquals |
+| **DateTime** | DateTimeEquals, DateTimeGreaterThan, DateTimeInRange, ... |
+| **Time of Day** | TimeOfDayEquals, TimeOfDayGreaterThan, TimeOfDayInRange, ... |
+| **IP** | IpMatch, IpNotMatch, IpInRange |
+| **Lists** | ListContains, ListNotContains, NormalizeList, NormalizeSet |
+| **Actions** | ActionMatches, SubOperationMatches |
+| **Quantifiers** | ANY, ALL, EXISTS |
+
+Each builtin is an enum variant in `RbacBuiltin` used for direct dispatch
+in `BinaryExpression` evaluation.
+
+## Key Invariants
+
+1. **No RVM backend** — RBAC is pure interpretation. Changes to the RVM do
+   not affect RBAC evaluation.
+
+2. **Short-circuit evaluation** — AND/OR evaluate left-to-right and stop
+   early. This is semantically important (not just an optimization).
+
+3. **Attribute resolution** — attributes are resolved from the evaluation
+   context at evaluation time. Missing attributes may produce errors or
+   false depending on the operator.
+
+4. **Case sensitivity** — string comparisons have both case-sensitive and
+   case-insensitive variants. Use the correct one.
+
+## Testing
+
+40+ YAML test files in `test_cases/` provide comprehensive coverage.
+Each test case specifies a condition string, evaluation context, and
+expected result.

--- a/docs/knowledge/builtin-system.md
+++ b/docs/knowledge/builtin-system.md
@@ -1,0 +1,189 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Builtin System
+
+Deep knowledge about regorus's builtin function infrastructure. Read this
+before adding, modifying, or debugging builtin functions.
+
+## Registration Pattern
+
+Builtin functions live in `src/builtins/`. Each module exports a `register`
+function that inserts entries into the `BUILTINS` lazy_static registry:
+
+```rust
+// In src/builtins/arrays.rs
+pub fn register(m: &mut BuiltinsMap<&'static str, BuiltinFcn>) {
+    m.insert("array.concat", (concat, 2));
+    m.insert("array.reverse", (reverse, 1));
+    m.insert("array.slice", (slice, 3));
+}
+```
+
+The tuple is `(function_pointer, arity)`. The function signature is:
+
+```rust
+fn concat(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value>
+```
+
+Parameters:
+- `span`: Source location for error messages
+- `params`: AST expressions (for error reporting, not evaluation)
+- `args`: Evaluated argument values
+- `strict`: Whether strict builtin error mode is enabled
+
+## Registration in BUILTINS
+
+All builtin modules register in `src/builtins/mod.rs` via a `lazy_static!` block:
+
+```rust
+lazy_static::lazy_static! {
+    pub static ref BUILTINS: BuiltinsMap<&'static str, BuiltinFcn> = {
+        let mut m = BuiltinsMap::new();
+        numbers::register(&mut m);
+        strings::register(&mut m);
+        // ...
+        #[cfg(feature = "regex")]
+        regex::register(&mut m);
+        // ...
+        m
+    };
+}
+```
+
+## Feature Gating
+
+Optional builtins must be feature-gated at two levels:
+
+**1. Cargo.toml** — declare the feature and optional dependency:
+```toml
+[features]
+regex = ["dep:regex"]
+```
+
+**2. Registration** — gate the register call:
+```rust
+#[cfg(feature = "regex")]
+regex::register(&mut m);
+```
+
+**3. Composite features** — add to `full-opa` and/or `opa-no-std` if the
+builtin is part of the OPA specification:
+```toml
+full-opa = ["regex", ...]
+opa-no-std = ["regex", ...]  # only if the dep supports no_std
+```
+
+## Argument Validation
+
+Every builtin must validate argument count first:
+
+```rust
+fn concat(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
+    let name = "array.concat";
+    ensure_args_count(span, name, params, args, 2)?;
+    // ...
+}
+```
+
+Then validate argument types. Use `ensure_*` helpers where available.
+
+## OPA Conformance Requirements
+
+**Error messages must match OPA exactly.** The OPA conformance test suite
+(`tests/opa.rs`) compares error messages literally. This means:
+
+- Function names in errors must match OPA's naming
+- Error message format must match OPA's format
+- Type error descriptions must match OPA's wording
+
+If an error message doesn't match, the conformance test fails. When
+implementing a builtin, compare against the OPA Go source for exact wording.
+
+## Strict vs Non-Strict Mode
+
+When `strict` is `true`:
+- Type errors are hard errors (return `Err(...)`)
+- Missing arguments are hard errors
+
+When `strict` is `false`:
+- Type errors return `Value::Undefined` (the OPA default)
+- This matches OPA's behavior where type mismatches silently fail
+
+## Undefined Argument Handling
+
+Builtins receive `Value::Undefined` when an argument expression evaluates to
+undefined. The interpreter checks this before calling:
+
+```rust
+if args.iter().any(|a| a == &Value::Undefined) {
+    return Ok(Value::Undefined);
+}
+```
+
+However, individual builtins may also need to handle Undefined for specific
+semantic reasons.
+
+## Both Execution Paths
+
+Builtins are shared between the interpreter and the RVM. Both use the same
+`BUILTINS` registry. When adding a builtin:
+
+1. The interpreter calls builtins via `eval_builtin_call()`
+2. The RVM resolves builtins by name from the same registry
+3. No special RVM registration is needed — it's automatic
+
+Test with both `cargo test` (interpreter) and RVM-specific tests.
+
+## Adding a New Builtin: Checklist
+
+1. Create the function in the appropriate `src/builtins/` module
+2. Follow the `(span, params, args, strict) -> Result<Value>` signature
+3. Call `ensure_args_count()` first
+4. Feature-gate if it requires optional dependencies
+5. Register in the module's `register()` function
+6. Add the module's `register()` call in `src/builtins/mod.rs` (feature-gated)
+7. Add to composite features (`full-opa`, `opa-no-std`) if OPA-standard
+8. Write tests (YAML format, see `tests/interpreter/`)
+9. Verify error messages match OPA exactly
+10. Update `docs/builtins.md`
+11. Run `cargo test --test opa` to verify OPA conformance
+12. Run `cargo xtask ci-debug` for full suite
+
+## Builtin Modules
+
+The modules in `src/builtins/` cover:
+- `aggregates` — count, sum, min, max, sort
+- `arrays` — concat, reverse, slice
+- `azure_policy` — Azure Policy-specific builtins (feature-gated)
+- `bitwise` — bitwise operations (and, or, negate, shift)
+- `comparison` — comparison operators (helper module, not separately registered)
+- `conversions` — to_number
+- `encoding` — base64, base64url, hex, json, yaml, urlquery
+- `glob` — match (feature-gated)
+- `graph` — walk, reachable (feature-gated)
+- `http` — http.send stub (feature-gated)
+- `net` — cidr_contains, cidr_intersects (feature-gated)
+- `numbers` — arithmetic, rounding, abs, rem
+- `objects` — get, keys, remove, union, filter
+- `opa` — runtime info (feature-gated)
+- `regex` — match, split, find (feature-gated)
+- `semver` — is_valid, compare (feature-gated)
+- `sets` — intersection, union, difference
+- `strings` — concat, contains, replace, split, trim, format, sprintf
+- `test` — internal test helpers (feature-gated: `opa-testutil`)
+- `time` — now_ns, parse_ns, date, clock (feature-gated)
+- `tracing` — trace, print
+- `types` — type_name, is_number, is_string, etc.
+- `units` — parse
+- `uuid` — rfc4122 (feature-gated)
+- `utils` — internal helpers
+
+## LRU Caching
+
+Some builtins use the LRU cache (`src/cache.rs`) for expensive compiled objects:
+- **Regex patterns**: up to 256 cached compiled `regex::Regex` objects
+- **Glob matchers**: up to 128 cached compiled `GlobMatcher` objects
+
+The cache is global, thread-safe (mutex-protected), and configurable via
+`cache::configure()`. The hard cap is 2^16 entries per cache type.

--- a/docs/knowledge/causality-and-partial-eval.md
+++ b/docs/knowledge/causality-and-partial-eval.md
@@ -1,0 +1,241 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Causality and Partial Evaluation
+
+Design considerations for future causality tracking and partial evaluation
+features. These are not yet implemented but the architecture is being
+designed to support them. Read this when making architectural decisions
+that may affect these future capabilities.
+
+## Partial Evaluation
+
+### What It Is
+
+Partial evaluation reduces a policy given **known** inputs while leaving
+**unknown** parts symbolic:
+
+```
+Full policy + known data + unknown input
+    → Simplified policy (only depends on unknown input)
+```
+
+Example:
+```rego
+allow {
+    input.role == "admin"       # Unknown (depends on input)
+    data.feature_enabled        # Known: true
+    input.department in {"eng", "security"}  # Unknown
+}
+```
+
+Partial evaluation with `data.feature_enabled = true`:
+```rego
+allow {
+    input.role == "admin"
+    input.department in {"eng", "security"}
+}
+```
+
+The `data.feature_enabled` check is eliminated because it's always true.
+
+### Use Cases
+
+1. **Policy optimization**: pre-evaluate known parts at compile/load time
+2. **Policy simplification**: show users what a policy means for their context
+3. **Incremental evaluation**: only re-evaluate changed parts
+4. **Query planning**: push policy decisions closer to data sources
+5. **Policy diffing**: compare simplified policies across configurations
+
+### Current Architecture Support
+
+**Scheduler dependency analysis**: The scheduler already identifies which
+statements depend on which variables. Statements that only depend on known
+variables can be evaluated. Statements with unknown dependencies remain
+symbolic.
+
+**RVM register model**: Registers could hold symbolic values alongside
+concrete ones. Instructions that operate on symbolic values produce symbolic
+results.
+
+**Value type extensibility**: The `Value` enum could be extended:
+```rust
+pub enum Value {
+    // ... existing variants ...
+    Symbolic(SymbolicExpr),  // Future: represents an unknown value
+}
+```
+
+**Compilation pipeline**: The hoister and scheduler already separate
+ground-truth computations from data-dependent ones. This separation is
+the foundation for partial evaluation.
+
+### Design Principles
+
+1. **Preserve semantics**: partially evaluated policy must produce identical
+   results to the original when the remaining unknowns are bound.
+
+2. **Undefined handling**: partial evaluation must correctly propagate
+   Undefined through symbolic expressions. This is the hardest part —
+   `not Undefined = true` means symbolic undefined propagation has
+   non-obvious results.
+
+3. **No information loss**: the residual policy must capture all constraints,
+   including those that were partially evaluated.
+
+4. **Composability**: partial evaluation results should be further partially
+   evaluatable as more inputs become known.
+
+### Implementation Considerations
+
+**Phase 1: Ground-truth elimination**
+- Identify statements where all variables are known
+- Evaluate them and replace with results
+- Remove always-true conditions, eliminate always-false rule bodies
+- This is the easiest phase and provides immediate value
+
+**Phase 2: Symbolic propagation**
+- Track symbolic values through expressions
+- Simplify expressions where possible (e.g., `true AND x` → `x`)
+- Handle Undefined propagation symbolically
+- Generate residual policy/program
+
+**Phase 3: Cross-rule analysis**
+- Partially evaluate virtual documents
+- Propagate known rule results into dependent rules
+- Handle default rules in partial context
+
+### Challenges
+
+- **Undefined propagation**: `not (Undefined)` = `true` makes symbolic
+  analysis non-trivial. A symbolic expression that might be Undefined
+  has different semantics under negation.
+
+- **Set/Object construction**: if any element is symbolic, the entire
+  collection construction may need to remain symbolic.
+
+- **Comprehensions**: partial evaluation of comprehensions requires
+  knowing which iterations are ground vs symbolic.
+
+- **Builtins**: some builtins are pure (suitable for partial evaluation),
+  others have side effects or depend on runtime state (`time.now_ns()`).
+
+## Causality Tracking
+
+### What It Is
+
+Causality tracking answers **why** a policy produced its result:
+- Which rules contributed to the decision?
+- What input/data values were decisive?
+- What would need to change to get a different result?
+
+### Use Cases
+
+1. **Audit**: prove why a request was allowed/denied
+2. **Debugging**: understand unexpected policy decisions
+3. **Compliance**: demonstrate that decisions follow documented logic
+4. **Counterfactual**: "what if the user had role X instead of Y?"
+
+### Current Infrastructure
+
+**Coverage tracking** (`coverage` feature):
+- Records which expressions were evaluated
+- Binary: evaluated or not evaluated
+- Doesn't track values or decision flow
+
+**Tracing** (`eval_query(query, tracing=true)`):
+- Captures evaluation steps
+- Provides more detail than coverage
+- Performance cost limits production use
+
+**RVM frame stack** (suspendable mode):
+- Frame-by-frame execution history
+- Instruction-level granularity available via single-step mode
+- Only in suspendable mode (not run-to-completion)
+
+**Active rules stack** (interpreter):
+- Tracks which rules are currently being evaluated
+- Used for cycle detection
+- Could be repurposed for causality
+
+### Design Vision
+
+#### Decision Tree
+
+A tree structure recording the evaluation path:
+
+```
+allow = true
+├── Rule: data.auth.allow (body 1 succeeded)
+│   ├── Statement: input.role == "admin" → true
+│   │   └── input.role = "admin" (from input)
+│   └── Statement: input.active == true → true
+│       └── input.active = true (from input)
+└── Default: data.auth.deny = false (not triggered)
+```
+
+#### Value Provenance
+
+Track where each value came from:
+- `input.role` → from user input
+- `data.allowed_roles` → from data document loaded at path X
+- `count(data.items)` → computed by builtin from data
+
+#### Counterfactual Analysis
+
+"What would change if `input.role` were `"viewer"` instead?"
+- Re-evaluate with modified input
+- Compare decision trees
+- Report which statements changed outcome
+
+### Architecture Implications
+
+1. **Opt-in overhead**: causality tracking adds memory and CPU cost.
+   Must be behind a feature flag or runtime configuration. Never in
+   the hot path for production evaluation.
+
+2. **Value annotation**: Values may need optional metadata:
+   ```rust
+   struct AnnotatedValue {
+       value: Value,
+       provenance: Option<Provenance>,  // Where it came from
+   }
+   ```
+
+3. **Evaluation hooks**: the interpreter/RVM need "observation points"
+   where causality information is recorded. These should be no-ops
+   when tracking is disabled.
+
+4. **Serializable traces**: decision trees and provenance information
+   need to be serializable (JSON) for audit logging and external
+   tooling.
+
+5. **Deterministic replay**: for counterfactual analysis, the evaluation
+   must be deterministic. This means:
+   - `time.now_ns()` must be mockable
+   - Random builtins must be seedable
+   - External data must be snapshotted
+
+### Connection to Partial Evaluation
+
+Causality and partial evaluation complement each other:
+- Partial evaluation identifies the **relevant** parts of a policy
+- Causality tracking explains the **decisions** within those parts
+- Together they answer: "given what we know, what decisions were made and why?"
+
+## Design Principles for Both Features
+
+1. **Keep evaluation logic pure** — side-effect-free functions are easier
+   to partially evaluate and track causally.
+
+2. **Document invariants explicitly** — invariants that hold during
+   evaluation are the foundation for symbolic reasoning.
+
+3. **Prefer exhaustive pattern matching** — every case handled explicitly
+   makes symbolic analysis tractable.
+
+4. **Separate observation from computation** — tracking infrastructure
+   should be orthogonal to evaluation logic.
+
+5. **Correct today, analyzable tomorrow** — current code should be
+   designed so these features can be added without fundamental restructuring.

--- a/docs/knowledge/compilation-pipeline.md
+++ b/docs/knowledge/compilation-pipeline.md
@@ -1,0 +1,260 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Compilation Pipeline
+
+Deep knowledge about the scheduler, loop hoisting, and destructuring planner.
+Read this before modifying `src/scheduler.rs` or `src/compiler/`.
+
+## Pipeline Overview
+
+```
+AST (with eidx, sidx, qidx indices)
+    ↓
+Scheduler  — determines statement execution order via topological sort
+    ↓
+LoopHoister — identifies loops to hoist and creates binding plans
+    ↓
+RVM Compiler — generates bytecode using hoisted info (if RVM feature)
+    ↓
+Program — bytecode + literal table + metadata
+```
+
+The interpreter also uses the scheduler and hoister output directly (without
+the RVM compiler step).
+
+## AST Indexing
+
+Every AST node carries an index for O(1) lookup of pre-computed information:
+
+- `Expr.eidx: u32` — unique expression index within a module
+- `LiteralStmt.sidx: u32` — statement index within a query
+- `Query.qidx: u32` — query index within a module
+
+These indices are assigned sequentially during parsing and used as keys into
+lookup tables by the scheduler and hoister.
+
+## Scheduler (`src/scheduler.rs`, ~1,218 lines)
+
+### Purpose
+
+Determine safe statement execution order within rule bodies. Statements may
+define and use variables, creating dependencies:
+
+```rego
+allow {
+    user := input.user           # defines 'user'
+    role := user.role            # uses 'user', defines 'role'
+    role == "admin"              # uses 'role'
+}
+```
+
+The scheduler topologically sorts statements so each statement's dependencies
+are satisfied before it executes.
+
+### Core Data Structures
+
+```rust
+struct Definition<Str> {
+    var: Str,               // Variable being defined (empty string = condition-only)
+    used_vars: Vec<Str>,    // Variables this definition depends on
+}
+
+struct StmtInfo<Str> {
+    definitions: Vec<Definition<Str>>,  // A statement can define multiple vars
+}
+
+struct QuerySchedule {
+    scope: Scope,           // Variable binding information
+    order: Vec<u16>,        // Computed statement execution order
+}
+```
+
+### Scheduling Algorithm
+
+The `schedule()` function performs topological sort:
+
+1. **Build dependency map**: `defining_stmts` maps each variable to the
+   statements that define it
+2. **Initialize**: track `defined_vars` (set), `scheduled` (bool array)
+3. **Process variables in discovery order**:
+   - For each variable, try to schedule all statements that define it
+   - A statement is schedulable when all its `used_vars` are already defined
+   - When a statement is scheduled, all its `defined_vars` become available
+   - This cascades — newly defined vars may unblock other statements
+4. **Handle cycles**: if not all statements scheduled, fall back to source order
+
+**Multi-definition statements**: A single statement can define multiple
+variables (e.g., `x, y := foo()`). These are handled with a queue-based
+approach that processes definitions within the statement iteratively.
+
+**Empty-variable statements**: Condition-only statements (like `x > 10`) use
+an empty string as the variable name. These are re-evaluated whenever any
+variable becomes defined, since they may become schedulable.
+
+### Analysis Pipeline
+
+`Analyzer.analyze()`:
+1. Add rules and aliases to scopes
+2. Gather functions into `FunctionTable`
+3. For each module → for each rule → for each query body:
+   - `analyze_query()` examines each statement
+   - Extracts `StmtInfo` (what variables defined/used)
+   - Calls `schedule()` to get execution order
+   - Stores result in `Schedule` lookup table
+
+## Loop Hoisting (`src/compiler/hoist.rs`, ~914 lines)
+
+### Purpose
+
+Identify iteration patterns that can be pre-computed and optimized:
+
+```rego
+# Before hoisting: interpreter must figure out iteration at runtime
+x[i] > 5    # Is 'i' a bound variable or should we iterate?
+
+# After hoisting: pre-computed as a loop with known structure
+HoistedLoop { key: i, collection: x, loop_type: IndexIteration }
+```
+
+### Core Data Structures
+
+```rust
+struct HoistedLoop {
+    loop_expr: Option<ExprRef>,   // The expression that generates the loop
+    key: Option<ExprRef>,         // Index/key variable
+    value: ExprRef,               // Iteration value
+    collection: ExprRef,          // Collection being iterated
+    loop_type: LoopType,          // IndexIteration or Walk
+}
+
+struct HoistedLoopsLookup {
+    statement_loops: Lookup<Vec<HoistedLoop>>,    // Per-statement loops
+    expr_loops: Lookup<Vec<HoistedLoop>>,         // Per-output-expression loops
+    expr_binding_plans: Lookup<BindingPlan>,       // Per-assignment binding plans
+    query_contexts: Lookup<ScopeContext>,           // Per-query scope info
+}
+```
+
+The `Lookup` type uses 2D indexing: `(module_index, item_index)`.
+
+### What Gets Hoisted
+
+**Index iteration**: `x[i]` where `i` is unbound → iterate over indices of `x`
+
+**Walk builtin**: `walk(input, [path, value])` → tree traversal loop
+
+**NOT hoisted**: `x[i]` where `i` is already bound (just an index access)
+
+### ScopeContext
+
+The hoister tracks variable binding state during analysis:
+
+```rust
+struct ScopeContext {
+    context_type: ContextType,           // Rule/Comprehension/Every/Query
+    bound_vars: BTreeSet<String>,        // All bound variables
+    current_scope_bound_vars: BTreeSet<String>,  // Newly bound in this scope
+    unbound_vars: BTreeSet<String>,      // Declared but not yet bound
+    local_vars: BTreeSet<String>,        // Scheduler-tracked locals
+}
+```
+
+The key method `should_hoist_as_loop()` determines whether a variable access
+should be a loop: true if the variable is unbound, local (per scheduler), or
+not in the bound set.
+
+### Analysis Flow
+
+```
+LoopHoister.populate()
+  → populate_module()
+    → populate_rule()  — bind parameters, extract key/value expressions
+      → populate_query()  — process statements in scheduled order
+        → populate_statement()  — analyze literals, store hoisted loops
+          → analyze_expr()  — recursive expression analysis
+            → detect RefBrack with unbound index → HoistedLoop
+            → detect walk() call → HoistedLoop
+            → detect assignment → BindingPlan
+```
+
+## Destructuring Planner (`src/compiler/destructuring_planner/`)
+
+### Purpose
+
+Create plans for pattern matching in assignments, parameters, and `some...in`:
+
+```rego
+[x, y] := func()          # Array destructuring
+{a: b} := obj             # Object destructuring
+some k, v in collection    # some-in binding
+```
+
+### Plan Types
+
+```rust
+enum DestructuringPlan {
+    Var(Span),                    // Bind value to variable
+    Ignore,                       // Wildcard (_)
+    EqualityExpr(ExprRef),        // Match against expression
+    EqualityValue(Value),         // Match against literal
+    Array { element_plans },      // Recursive array destructuring
+    Object { field_plans, dynamic_fields },  // Recursive object destructuring
+}
+
+enum BindingPlan {
+    Destructuring(DestructuringPlan),
+    Assignment(AssignmentPlan),
+    SomeIn(SomeInPlan),
+    LoopIndex(LoopIndexPlan),
+    Parameter(ParameterPlan),
+}
+```
+
+### Assignment Plans
+
+Two assignment operators have different binding semantics:
+
+- **`:=`** (ColonEquals): Only LHS can bind variables. Strict.
+- **`=`** (Equals): Both sides can bind. Two-pass analysis needed.
+
+### Variable Binding Context
+
+```rust
+trait VariableBindingContext {
+    fn is_var_unbound(&self, var_name: &str, scoping: ScopingMode) -> bool;
+    fn has_same_scope_binding(&self, var_name: &str) -> bool;
+}
+```
+
+`ScopingMode::RespectParent` prevents shadowing. `ScopingMode::AllowShadowing`
+allows it (used for function parameters).
+
+## Key Invariants
+
+1. **Scheduled order must respect dependencies** — if statement B uses a
+   variable defined by statement A, A must execute before B.
+
+2. **Hoisted loops must match runtime behavior** — the hoister's analysis of
+   bound vs unbound must match what the interpreter/RVM sees at runtime.
+
+3. **Binding plans must be complete** — every variable that appears in a
+   destructuring pattern must have a binding plan (Var, Ignore, or Equality).
+
+4. **Lookup indices must be consistent** — the same `(module_index, eidx/sidx/qidx)`
+   must refer to the same AST node across scheduler, hoister, and executor.
+
+## Common Pitfalls
+
+1. **Scope context inheritance** — child contexts (comprehensions, every)
+   inherit bound_vars from parent but have their own new bindings.
+
+2. **Multi-definition statements** — a single `=` can bind variables on
+   both sides, creating complex dependency chains.
+
+3. **Loop hoisting vs bound variables** — `x[i]` is a loop only if `i` is
+   unbound. Mistakenly hoisting a bound index access creates incorrect
+   iteration behavior.
+
+4. **Query schedule vs source order** — the scheduled order may differ from
+   source order. Code that assumes source order will break.

--- a/docs/knowledge/engine-api.md
+++ b/docs/knowledge/engine-api.md
@@ -1,0 +1,179 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Engine API
+
+Deep knowledge about the public `Engine` API (`src/engine.rs`). Read this
+before modifying the engine's public interface or evaluation flow.
+
+## Engine Structure
+
+```rust
+pub struct Engine {
+    modules: Rc<Vec<Ref<Module>>>,              // Loaded policy modules
+    interpreter: Interpreter,                    // Execution engine
+    prepared: bool,                             // Compilation state flag
+    rego_v1: bool,                              // Language version
+    execution_timer_config: Option<ExecutionTimerConfig>,
+    policy_length_config: PolicyLengthConfig,    // File size limits
+}
+```
+
+## Primary API Flow
+
+### 1. Policy Loading
+
+```rust
+pub fn add_policy(&mut self, path: String, rego: String) -> Result<String>
+pub fn add_policy_from_file(&mut self, path: impl AsRef<Path>) -> Result<String>
+```
+
+- Parses Rego source via Lexer → Parser → AST
+- Returns the package name (e.g., `"data.test"`)
+- Sets `prepared = false` to trigger recompilation on next eval
+- Enforces `PolicyLengthConfig` limits
+
+### 2. Data and Input
+
+```rust
+pub fn add_data(&mut self, data: Value) -> Result<()>  // Merge into data document
+pub fn add_data_json(&mut self, data: &str) -> Result<()>
+pub fn set_input(&mut self, input: Value)
+pub fn set_input_json(&mut self, input: &str) -> Result<()>
+pub fn clear_data(&mut self)
+```
+
+`add_data()` merges into the existing data document. It requires the value
+to be an object (checked). Conflict detection on merge.
+
+### 3. Evaluation
+
+| Method | Returns | Use Case |
+|--------|---------|----------|
+| `eval_rule(rule)` | `Value` | Direct rule evaluation (fast) |
+| `eval_query(query, tracing)` | `QueryResults` | OPA-compatible with bindings |
+| `eval_bool_query(query)` | `bool` | Boolean shortcut |
+| `eval_allow_query()` | `bool` | Common deny-by-default pattern |
+| `eval_modules(tracing)` | `Value` | Evaluate all loaded modules |
+
+### 4. Compilation (for repeated evaluation)
+
+```rust
+pub fn compile_for_target(&mut self) -> Result<CompiledPolicy>
+pub fn compile_with_entrypoint(&mut self, rule: &Rc<str>) -> Result<CompiledPolicy>
+```
+
+Returns `CompiledPolicy` — an immutable, precompiled artifact that can be
+evaluated many times with different inputs:
+
+```rust
+let compiled = engine.compile_for_target()?;
+// Later, potentially in a different thread:
+let result = compiled.eval_with_input(input)?;
+```
+
+### 5. Configuration
+
+```rust
+pub fn set_rego_v0(&mut self, enabled: bool)     // Language version
+pub fn set_execution_timer_config(config)         // Timeout limits
+pub fn set_policy_length_config(config)           // File size limits
+pub fn set_strict_builtin_errors(b: bool)         // Error vs Undefined for type mismatches
+pub fn add_extension(name, arity, func)           // Custom functions
+```
+
+## CompiledPolicy
+
+```rust
+pub struct CompiledPolicy {
+    inner: Rc<CompiledPolicyData>,
+}
+
+struct CompiledPolicyData {
+    modules: Rc<Vec<Ref<Module>>>,
+    schedule: Option<Rc<Schedule>>,           // Pre-computed statement order
+    rules: Map<String, Vec<Ref<Rule>>>,       // Rule path → rules
+    default_rules: Map<String, Vec<...>>,     // Default rules
+    imports: BTreeMap<String, Ref<Expr>>,
+    functions: FunctionTable,                 // User-defined functions
+    rule_paths: Set<String>,
+    loop_hoisting_table: HoistedLoopsLookup,  // Pre-computed loop info
+    data: Option<Value>,                      // Preloaded data
+    strict_builtin_errors: bool,
+    extensions: Map<String, (u8, Rc<Box<dyn Extension>>)>,
+}
+```
+
+**Benefits of CompiledPolicy:**
+- Schedule, loop hoisting, and function table pre-computed once
+- Can be cloned cheaply (Rc internals)
+- Supports repeated evaluation with different inputs
+- Thread-safe when using `arc` feature
+
+## Internal Evaluation Flow
+
+When `eval_rule()` is called:
+
+1. **Preparation** (if not `prepared`):
+   - Gather all functions from modules → `FunctionTable`
+   - Run scheduler on all queries → `Schedule`
+   - Run loop hoister → `HoistedLoopsLookup`
+   - Build `CompiledPolicyData`
+   - Set `prepared = true`
+
+2. **Interpreter setup**:
+   - Set data and input on interpreter
+   - Set current module context
+
+3. **Evaluation**:
+   - Find rule in `compiled_policy.rules`
+   - Call `interpreter.eval_rule()`
+   - Return result
+
+## Multiple Module Management
+
+- Modules stored as `Rc<Vec<Ref<Module>>>`
+- Each module declares a package namespace (e.g., `package auth`)
+- Rules qualified by package path: `data.auth.allow`
+- Imports resolve cross-module references
+- Functions tracked globally in `FunctionTable`
+
+## Extensions API
+
+Custom functions can be registered at runtime:
+
+```rust
+engine.add_extension(
+    "custom.check".to_string(),
+    2,  // arity
+    Rc::new(Box::new(|args| -> Result<Value> {
+        // implementation
+    })),
+)?;
+```
+
+Extensions are available to Rego policies as builtin functions.
+
+## Metadata Access
+
+```rust
+pub fn get_packages(&self) -> Result<Vec<String>>      // Package names
+pub fn get_policies(&self) -> Result<Vec<Source>>       // Policy sources
+pub fn get_policies_as_json(&self) -> Result<String>    // JSON representation
+pub fn get_coverage_report(&self) -> Result<Report>     // Code coverage
+```
+
+## Key Design Decisions
+
+1. **Lazy compilation** — policies aren't compiled until first evaluation.
+   `prepared` flag tracks whether compilation is needed.
+
+2. **Data merging** — `add_data()` merges, doesn't replace. Multiple data
+   sources accumulate into the data document.
+
+3. **Input replacement** — `set_input()` replaces, doesn't merge. Each
+   evaluation gets a fresh input.
+
+4. **Clone semantics** — `Engine::clone()` clones all persistent state
+   (policies, data, configuration) but resets runtime state (processed
+   rules, caches). The clone is ready for independent evaluation.

--- a/docs/knowledge/error-handling-migration.md
+++ b/docs/knowledge/error-handling-migration.md
@@ -1,0 +1,194 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Error Handling Migration
+
+Deep knowledge about regorus's error handling patterns and the ongoing
+migration from `anyhow` to `thiserror`. Read this before adding error
+handling to new code or modifying existing error paths.
+
+## Current State
+
+The codebase has two error handling approaches coexisting:
+
+### Legacy: anyhow (widespread)
+
+Most of the codebase uses `anyhow::Result` with `bail!()` and `anyhow!()`:
+
+```rust
+use anyhow::{anyhow, bail, Result};
+
+fn eval_something(&mut self) -> Result<Value> {
+    let v = map.get("key").ok_or_else(|| anyhow!("missing key"))?;
+    if condition_fails {
+        bail!("evaluation failed: {reason}");
+    }
+    Ok(value)
+}
+```
+
+Found in: `src/interpreter.rs`, `src/engine.rs`, `src/parser.rs`,
+`src/lexer.rs`, `src/value.rs`, `src/number.rs`, `src/builtins/`, and most
+other modules.
+
+### Target: thiserror (RVM leads)
+
+The RVM uses strongly typed error enums:
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum VmError {
+    #[error("Execution stopped: exceeded maximum instruction limit of {limit} after {executed} instructions (pc={pc})")]
+    InstructionLimitExceeded { limit: usize, executed: usize, pc: usize },
+
+    #[error("Register index {index} out of bounds (pc={pc}, register_count={register_count})")]
+    RegisterIndexOutOfBounds { index: u8, pc: usize, register_count: usize },
+
+    // ... 30+ variants covering every VM error case
+}
+
+pub type Result<T> = core::result::Result<T, VmError>;
+```
+
+Found in: `src/rvm/vm/errors.rs`
+
+## The VmError Pattern (Reference Implementation)
+
+Key design principles visible in `VmError`:
+
+**1. Every variant carries context:**
+```rust
+InstructionLimitExceeded { limit: usize, executed: usize, pc: usize }
+```
+Not just "limit exceeded" — includes the limit, actual count, and program counter.
+
+**2. Program counter in every variant:**
+```rust
+// Every single variant includes `pc: usize`
+RegisterNotObject { register: u8, value: Value, pc: usize },
+LiteralIndexOutOfBounds { index: u16, pc: usize },
+```
+This is a debugging aid — every error can be traced to the exact instruction.
+
+**3. Exhaustive coverage:**
+30+ variants covering every known error case. No catch-all "Other(String)".
+
+**4. Derives Clone and PartialEq:**
+```rust
+#[derive(Error, Debug, Clone, PartialEq)]
+```
+Clone enables error propagation without ownership transfer. PartialEq enables
+testing error conditions precisely.
+
+**5. Type alias for ergonomics:**
+```rust
+pub type Result<T> = core::result::Result<T, VmError>;
+```
+
+**6. Bridge from anyhow:**
+```rust
+impl From<anyhow::Error> for VmError {
+    fn from(err: anyhow::Error) -> Self {
+        VmError::ArithmeticError { message: format!("{}", err), pc: 0 }
+    }
+}
+```
+This allows the RVM to call into legacy code that returns `anyhow::Result`.
+
+## Migration Strategy
+
+### For New Code
+
+**Always use thiserror.** Define a module-specific error enum:
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum MySubsystemError {
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
+    #[error("resource limit exceeded: {current} > {limit}")]
+    ResourceLimitExceeded { current: usize, limit: usize },
+}
+
+pub type Result<T> = core::result::Result<T, MySubsystemError>;
+```
+
+### For Existing Code
+
+When modifying existing functions that use `anyhow`:
+- **Within the same module**: continue with `anyhow` for consistency
+- **At module boundaries**: consider wrapping `anyhow::Error` in a typed variant
+- **Incremental migration**: converting a whole module at once is better than
+  mixing styles within a single module
+
+### Bridge Pattern
+
+When typed-error code calls anyhow code (or vice versa):
+
+```rust
+// Typed → anyhow (automatic via anyhow's From impl)
+fn caller() -> anyhow::Result<Value> {
+    typed_function()?;  // VmError auto-converts to anyhow::Error
+    Ok(value)
+}
+
+// Anyhow → typed (explicit conversion needed)
+fn caller() -> Result<Value, VmError> {
+    anyhow_function().map_err(|e| VmError::Internal {
+        message: format!("{}", e),
+        pc: current_pc,
+    })?;
+    Ok(value)
+}
+```
+
+## Error Message Guidelines
+
+### For OPA Conformance
+
+Builtin error messages **must match OPA exactly** — the conformance test suite
+compares literally. When implementing builtins, check the OPA Go source.
+
+### For Internal Errors
+
+- Include enough context to diagnose without a debugger
+- Include identifiers (register index, PC, rule name, etc.)
+- Don't include sensitive data (user input, policy content)
+- Use structured fields, not string formatting:
+
+```rust
+// ✗ Bad
+#[error("register {0} out of bounds at pc {1}")]
+RegisterOutOfBounds(u8, usize),
+
+// ✓ Good — named fields are self-documenting
+#[error("register index {index} out of bounds (pc={pc}, register_count={register_count})")]
+RegisterIndexOutOfBounds { index: u8, pc: usize, register_count: usize },
+```
+
+## Panic Safety Connection
+
+Error handling is the front line of panic safety. The deny lints forbid
+`unwrap()`, `expect()`, `panic!()`, etc. Every fallible operation must return
+`Result`. This is not just style — in daemon mode, a panic crashes the service.
+
+The error migration makes this stronger: with typed errors, every failure mode
+is enumerated and the compiler ensures all are handled. With `anyhow`, errors
+are opaque and may be accidentally swallowed.
+
+## no_std Compatibility
+
+Both `anyhow` and `thiserror` support `no_std` with `default-features = false`:
+
+```toml
+anyhow = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
+```
+
+Error types must use `alloc::string::String` instead of `std::string::String`
+and avoid `std::io::Error` without a feature gate.

--- a/docs/knowledge/feature-composition.md
+++ b/docs/knowledge/feature-composition.md
@@ -1,0 +1,183 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Feature Composition
+
+Deep knowledge about regorus's feature flag system and the risks of
+non-default feature combinations. Read this before adding features or
+modifying feature-gated code.
+
+## Feature Architecture
+
+### Default Features
+
+```toml
+default = ["full-opa", "arc", "rvm"]
+```
+
+- **`full-opa`**: All OPA-compatible builtins. Implies `std`.
+- **`arc`**: `Arc` instead of `Rc` for thread safety.
+- **`rvm`**: Rego Virtual Machine compilation and execution.
+
+### Composite Features
+
+**`full-opa`** includes: base64, base64url, coverage, glob, graph, hex, http,
+jsonschema, net, opa-runtime, regex, cache, semver, std, time, uuid, urlquery,
+yaml.
+
+**`opa-no-std`** includes: arc, base64, base64url, coverage, graph, hex,
+no_std, opa-runtime, regex, semver, lazy_static/spin_no_std. Note this
+**excludes** builtins that require `std` (glob, time, jsonschema, yaml, etc).
+
+### The no_std / std Boundary
+
+The crate is `#![no_std]` by default with `extern crate alloc`.
+
+- **`std`** feature: enables `std` library, parking_lot, filesystem, threading
+- **`no_std`** feature: enables `lazy_static/spin_no_std` for spinlock-based lazy statics
+
+**These are NOT mutually exclusive in Cargo.** If both are enabled, `std` wins.
+But `no_std` should be tested alone:
+
+```bash
+cargo xtask test-no-std  # Builds for thumbv7m-none-eabi
+```
+
+### The arc Feature
+
+Controls whether shared data uses `Rc` or `Arc`:
+
+```rust
+// In src/lib.rs (conditional type alias)
+#[cfg(feature = "arc")]
+type Rc<T> = alloc::sync::Arc<T>;
+#[cfg(not(feature = "arc"))]
+type Rc<T> = alloc::rc::Rc<T>;
+```
+
+**`arc` is default.** Disabling it gives single-threaded performance but breaks
+thread safety. The FFI crate's contention detection (`contention_checks`)
+requires `arc`.
+
+## Known Pitfalls
+
+### Issue #595 Pattern
+
+Feature combinations that compile individually may fail together. Example:
+a feature adds a dependency that conflicts with `no_std`, or a feature-gated
+module uses `std` types without a feature gate.
+
+**Prevention:**
+- Always test with `--no-default-features` plus minimal feature sets
+- CI checks key combinations explicitly
+
+### Compilation Verification Matrix
+
+When adding or modifying features, verify these combinations compile:
+
+```bash
+# Minimal (no_std, no arc, no rvm)
+cargo check --no-default-features
+
+# no_std with arc
+cargo check --no-default-features --features arc,opa-no-std
+
+# std with arc and rvm (common production config)
+cargo check --no-default-features --features std,arc,rvm
+
+# Everything
+cargo check --all-features
+
+# The full CI suite checks more combinations
+cargo xtask ci-debug
+```
+
+### Feature-Gated Code Correctness
+
+Common mistakes:
+
+**1. Using std types without gate:**
+```rust
+// ✗ Bad — breaks no_std
+use std::collections::HashMap;
+
+// ✓ Good — available in no_std via alloc
+use alloc::collections::BTreeMap;
+
+// ✓ Good — gated when std is required
+#[cfg(feature = "std")]
+use std::path::Path;
+```
+
+**2. Feature implies another but not declared:**
+```rust
+// ✗ Bad — regex module uses std but doesn't declare dependency
+[features]
+regex = ["dep:regex"]  # regex crate needs std!
+
+// ✓ Good — declare the implication
+regex = ["dep:regex"]  # regex default-features=false works in no_std
+```
+
+**3. Conditional compilation in wrong direction:**
+```rust
+// ✗ Bad — dead code when feature absent, no compile error
+#[cfg(feature = "myfeature")]
+fn helper() { ... }
+
+fn caller() {
+    helper();  // ERROR: `helper` doesn't exist without myfeature
+}
+
+// ✓ Good — gate the caller too
+#[cfg(feature = "myfeature")]
+fn caller() {
+    helper();
+}
+```
+
+### docsrs Annotation
+
+Public feature-gated APIs must have the docsrs annotation so docs.rs shows
+which feature is required:
+
+```rust
+#[cfg(feature = "myfeature")]
+#[cfg_attr(docsrs, doc(cfg(feature = "myfeature")))]
+pub fn my_function() -> Result<()> { .. }
+```
+
+## Adding a New Feature: Checklist
+
+1. Add to `[features]` in `Cargo.toml` with optional dependency
+2. Gate the module: `#[cfg(feature = "myfeature")] mod myfeature;`
+3. Gate registration (builtins, languages, etc.)
+4. Gate public API with docsrs annotation
+5. Add to `full-opa` if it's an OPA-standard feature
+6. Add to `opa-no-std` if it works without std
+7. Verify compilation with the matrix above
+8. Run `cargo xtask ci-debug` for the full suite
+9. Consider adding the combination to CI if it's a common configuration
+
+## Dependencies and no_std
+
+When adding dependencies:
+- Check if the crate supports `no_std` (look for `default-features = false`)
+- Use `default-features = false` and enable only needed features
+- If the crate requires `std`, the feature must imply `std`
+- Prefer `core`/`alloc` over external crates where feasible
+
+Current dependency pattern:
+```toml
+serde = { version = "1.0", default-features = false, features = ["derive", "rc", "alloc"] }
+regex = { version = "1.12", optional = true, default-features = false }
+```
+
+## The Rc Type Alias
+
+The crate defines a type alias `Rc` that maps to either `alloc::rc::Rc` or
+`alloc::sync::Arc` based on the `arc` feature. This alias is used throughout
+the codebase — in `Value`, `Number`, and everywhere shared ownership is needed.
+
+**Never use `alloc::rc::Rc` or `alloc::sync::Arc` directly in the core crate.**
+Always use the type alias `Rc` to ensure the `arc` feature works correctly.

--- a/docs/knowledge/ffi-boundary.md
+++ b/docs/knowledge/ffi-boundary.md
@@ -1,0 +1,212 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: FFI Boundary
+
+Deep knowledge about regorus's foreign function interface and multi-language
+binding architecture. Read this before modifying `bindings/` or the core
+library's public API.
+
+## Architecture
+
+```
+                    regorus (Rust core library)
+                              │
+                    bindings/ffi/ (base FFI crate)
+                              │
+        ┌────────┬────────┬───┴───┬────────┬────────┐
+        │        │        │       │        │        │
+     C/C++    C#/NuGet  Java   Python   Ruby    WASM
+   (cbindgen) (csbindgen)(jni-rs)(PyO3) (magnus)(wasm-pack)
+     CMake    MSBuild    Maven  maturin bundler  npm
+```
+
+The FFI crate (`bindings/ffi/`) is the **security boundary**. Rust's compiler
+guarantees do not extend across it.
+
+## Opaque Handle Pattern
+
+All Rust objects are exposed to C as opaque pointers:
+
+```rust
+// Rust side
+pub struct RegorusEngine {
+    engine: Handle<::regorus::Engine>,  // Rc<RefCell<>> or Arc<RwLock<>>
+}
+
+#[no_mangle]
+pub extern "C" fn regorus_engine_new() -> *mut RegorusEngine {
+    Box::into_raw(Box::new(RegorusEngine::new(engine)))
+}
+
+#[no_mangle]
+pub extern "C" fn regorus_engine_drop(engine: *mut RegorusEngine) {
+    if let Ok(e) = to_ref(engine) {
+        unsafe { let _ = Box::from_raw(ptr::from_mut(e)); }
+    }
+}
+```
+
+**Invariant:** Every `Box::into_raw()` must have a corresponding `Box::from_raw()`
+in a drop function. Missing drops = memory leaks.
+
+## Null Pointer Validation
+
+Every pointer parameter is validated at the FFI boundary:
+
+```rust
+pub(crate) fn to_ref<'a, T>(t: *mut T) -> Result<&'a mut T> {
+    unsafe { t.as_mut().ok_or_else(|| anyhow!("null pointer")) }
+}
+
+pub(crate) fn from_c_str(s: *const c_char) -> Result<String> {
+    if s.is_null() { bail!("null pointer"); }
+    unsafe { CStr::from_ptr(s).to_str().map_err(|e| anyhow!("invalid utf8: {e}")).map(|s| s.to_string()) }
+}
+```
+
+**Invariant:** No FFI function may dereference a pointer without checking for null.
+
+## Contention Detection
+
+The FFI handle uses configurable locking (`bindings/ffi/src/lock.rs`):
+
+| Feature flags | Handle type | Cost | Safety |
+|---------------|-------------|------|--------|
+| `std` + `contention_checks` | `Arc<RwLock<T>>` | Higher | Detects concurrent access |
+| `std` only | `Rc<RefCell<T>>` | Lower | Single-thread assumption |
+| `no_std` | `Rc<RefCell<T>>` | Lowest | Single-thread only |
+
+The contention error message explicitly tells users to clone:
+> "regorus engine handle is already in use; clone the engine before sharing across threads"
+
+## Panic Containment and Poisoning
+
+**Every FFI entry point wraps in `with_unwind_guard()`** which:
+
+1. Checks if engine is already poisoned → return `RegorusStatus::Poisoned`
+2. Installs a temporary panic hook to capture backtrace
+3. Calls `panic::catch_unwind()` around the function body
+4. If panic caught → permanently poisons engine via `AtomicBool`
+5. Returns `RegorusStatus::Panic` with the captured backtrace
+
+**Once poisoned, the engine is PERMANENTLY dead.** All subsequent calls return
+`RegorusStatus::Poisoned`. There is no recovery. This is intentional — after a
+panic, internal state may be corrupt.
+
+## Result Encoding
+
+All FFI functions return `RegorusResult`:
+
+```c
+typedef struct {
+    RegorusStatus status;        // Ok, Error, Panic, Poisoned, ...
+    RegorusDataType data_type;   // None, String, Boolean, Integer, Pointer
+    char* output;                // Owned by Rust — caller MUST call regorus_result_drop()
+    bool bool_value;
+    long long int_value;
+    void* pointer_value;
+    char* error_message;         // Owned by Rust — freed by regorus_result_drop()
+} RegorusResult;
+```
+
+**CRITICAL:** String ownership transfers to C via `CString::into_raw()`. If the
+caller doesn't call `regorus_result_drop()`, memory leaks.
+
+## Binary Buffer Pattern
+
+For binary data (serialized programs), `RegorusBuffer` transfers Vec ownership:
+
+```rust
+pub struct RegorusBuffer {
+    pub data: *mut u8,
+    pub len: usize,
+    pub capacity: usize,
+}
+```
+
+Created via `RegorusBuffer::from_vec()` (which `mem::forget()`s the Vec),
+freed via `regorus_buffer_drop()` (which reconstructs and drops the Vec).
+
+## Language-Specific Binding Patterns
+
+### C — Raw FFI
+No wrapper. Manual `regorus_result_drop()` and `regorus_engine_drop()` calls.
+Error handling via status code checks.
+
+### C++ — RAII
+`regorus.hpp` wraps with:
+- `Result` class: move-only, destructor calls `regorus_result_drop()`
+- `Engine` class: destructor calls `regorus_engine_drop()`
+- Copy prevention via deleted copy constructor/assignment
+
+### C# — SafeHandle with HandleGate
+Most sophisticated wrapper:
+- `SafeHandle` integrates with .NET finalizer
+- `HandleGate` tracks in-flight operations
+- `DangerousAddRef()`/`DangerousRelease()` pins handle during native calls
+- Dispose waits up to 50ms for in-flight calls to drain
+- Thread-safe concurrent access tracking
+
+### Java — AutoCloseable + JNI
+- Stores opaque `long` pointer (64-bit address)
+- `AutoCloseable` for `try-with-resources` blocks
+- `close()` calls `nativeDestroyEngine()`
+
+### Python — PyO3 Direct Embedding
+- `#[pyclass(unsendable)]` embeds Rust Engine in Python object
+- Python GC owns the object, Rust `Drop` is automatic
+- No separate FFI layer — PyO3 marshals directly
+
+### Go — cgo
+- Stores `*C.RegorusEngine` opaque pointer
+- `defer` for cleanup ordering
+- Manual CString conversion with `C.CString()`/`C.free()`
+
+### Ruby — Magnus Native Extension
+- Rust struct wrapped as Ruby class
+- Ruby GC manages lifecycle via finalizer
+
+### WASM — wasm-pack
+- Compiled to WebAssembly, exposed via JavaScript bindings
+- No pointer management — WASM linear memory handles it
+
+## Custom Allocator Support
+
+The FFI crate supports host-provided allocators:
+
+```rust
+#[cfg(feature = "custom_allocator")]
+extern "C" {
+    fn regorus_aligned_alloc(alignment: usize, size: usize) -> *mut u8;
+    fn regorus_free(ptr: *mut u8);
+}
+```
+
+This allows C#/JVM/Go hosts to provide their own allocator, which is important
+for memory tracking and limit enforcement in managed runtimes.
+
+## Impact of Core API Changes
+
+When changing the core library's public API:
+
+1. **Every binding must be updated** — 9 language targets
+2. **FFI function signature changes** require updating:
+   - `bindings/ffi/src/engine.rs` (or relevant FFI module)
+   - C/C++ headers (auto-generated by cbindgen, but verify)
+   - C# P/Invoke declarations
+   - Java JNI native method declarations
+   - Go cgo function declarations
+   - WASM bindings
+3. **Run `cargo xtask test-all-bindings`** to verify all targets
+4. **New public methods** need FFI wrappers, documentation in all languages
+5. **Behavioral changes** may need binding-level test updates
+
+## Security Considerations
+
+- The FFI boundary is where type safety ends — validate everything
+- Pointer arithmetic for array parameters must check bounds carefully
+- String encoding (UTF-8 vs platform) must be validated at the boundary
+- Panic containment prevents Rust panics from unwinding into C/C++
+- Poisoning prevents use-after-panic of potentially corrupt state
+- Memory ownership must be crystal clear — who allocates, who frees

--- a/docs/knowledge/interpreter-architecture.md
+++ b/docs/knowledge/interpreter-architecture.md
@@ -1,0 +1,216 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Interpreter Architecture
+
+Deep knowledge about the tree-walking interpreter (`src/interpreter.rs`).
+This is a 4,400+ line file and the legacy execution path. Read this before
+modifying evaluation logic.
+
+## Core Data Structures
+
+### Interpreter State
+
+```rust
+pub struct Interpreter {
+    compiled_policy: Rc<CompiledPolicyData>,
+    data: Value,                           // Data document (rules materialize here)
+    input: Value,                          // User-provided input
+    with_document: Value,                  // Temporary overrides via `with`
+    scopes: Vec<Scope>,                    // Variable binding stack
+    contexts: Vec<Context>,                // Evaluation context stack
+    processed: BTreeSet<Ref<Rule>>,        // Rules already evaluated
+    processed_paths: Value,                // Data paths already evaluated
+    rule_values: RuleValues,               // Cached rule evaluation results
+    active_rules: Vec<Ref<Rule>>,          // Stack for cycle detection
+    loop_var_values: ExprLookup,           // Loop variable cache
+    builtins_cache: BTreeMap<..., Value>,   // Builtin result cache
+    execution_timer: ExecutionTimer,       // Time limit enforcement
+    extensions: Map<String, (u8, Rc<Box<dyn Extension>>)>,
+    with_functions: BTreeMap<String, FunctionModifier>,
+}
+```
+
+### Context Stack
+
+Each query/rule evaluation pushes a `Context`:
+
+```rust
+struct Context {
+    key_expr: Option<ExprRef>,      // Object comprehension key
+    output_expr: Option<ExprRef>,   // Output value expression
+    value: Value,                   // Accumulated results
+    result: Option<QueryResult>,    // For user queries (bindings + expressions)
+    rule_ref: Option<ExprRef>,      // Reference to current rule
+    rule_value: Value,              // Computed rule value
+    is_compr: bool,                 // Comprehension context
+    is_set: bool,                   // Set rule context
+    is_old_style_set: bool,         // Legacy set syntax
+    early_return: bool,             // Break out of evaluation
+}
+```
+
+Contexts are pushed for: rule bodies, comprehensions, user queries. The
+context determines how results are collected (array, set, object, or query
+result bindings).
+
+### Scope Stack
+
+Variables are tracked in a stack of scopes:
+
+```rust
+type Scope = BTreeMap<SourceStr, Value>;
+```
+
+Each function/rule call pushes a new scope. Variable lookup searches from
+innermost to outermost scope.
+
+## Evaluation Call Hierarchy
+
+```
+eval_rule()                          Entry: evaluate a named rule
+  └─ eval_rule_impl()               Dispatch by rule type (Spec/Default/Func)
+       └─ eval_rule_bodies()         Evaluate rule body alternatives
+            └─ eval_query()          Execute a query (ordered statements)
+                 └─ eval_stmts()     Execute statements in scheduled order
+                      └─ eval_stmt() Single statement dispatch
+                           └─ eval_stmt_impl()
+                                ├─ Expr → eval_expr()
+                                ├─ SomeIn → eval_some_in()
+                                ├─ SomeVars → variable declaration
+                                ├─ NotExpr → negation wrapper
+                                └─ Every → eval_every()
+
+eval_expr()                          Expression dispatcher (25+ variants)
+  ├─ Literals → direct Value
+  ├─ Var/RefDot/RefBrack → eval_chained_ref_dot_or_brack()
+  ├─ BinExpr → eval_bin_expr()
+  ├─ BoolExpr → eval_bool_expr()
+  ├─ ArithExpr → eval_arith_expr()
+  ├─ Call → eval_call()
+  ├─ ArrayCompr/SetCompr/ObjectCompr → eval_*_compr()
+  ├─ Array/Set/Object → eval_array/set/object()
+  └─ AssignExpr → execute_destructuring_plan()
+```
+
+## Rule Evaluation Lifecycle
+
+### 1. Rule Discovery
+
+When code references `data.pkg.rule`, the interpreter calls
+`ensure_rule_evaluated()` which:
+1. Checks if the path has initial data (from `add_data()`)
+2. Looks for rules that define that path in `compiled_policy.rules`
+3. Evaluates those rules if not already in `self.processed`
+
+### 2. Rule Bodies
+
+A rule can have multiple bodies (alternatives). Bodies are evaluated in order.
+**First successful body wins** — remaining bodies are skipped.
+
+```rego
+allow { condition_a }  # Body 1
+allow { condition_b }  # Body 2 — only tried if body 1 fails
+```
+
+### 3. Result Collection
+
+Results are collected into `ctx.value` based on rule type:
+- **Complete rules**: single Value
+- **Partial set rules**: `Value::Set` accumulating members
+- **Partial object rules**: `Value::Object` accumulating key-value pairs
+
+### 4. Data Materialization
+
+`update_rule_value()` navigates the rule's path and inserts the result into
+`self.data`. This is how rules become "virtual documents" accessible via
+`data.pkg.rule`.
+
+**Precedence**: initial data > evaluated rules > default rules.
+
+## Variable Lookup
+
+`lookup_var()` is the main variable resolution function. The search order:
+
+1. Local scopes (innermost to outermost)
+2. `input` document (if name is "input")
+3. `data` document (if name is "data") — triggers lazy rule evaluation
+4. Imported variables from other packages
+5. Returns `Undefined` if not found
+
+**Key subtlety**: Looking up a `data` path may trigger rule evaluation, which
+may trigger further lookups — this is how lazy evaluation chains work.
+
+## The `with` Modifier
+
+`with` temporarily overrides data, input, or functions during evaluation:
+
+```rego
+x = eval { y = f(1) with f as g with data.config as override }
+```
+
+### State Save/Restore Pattern
+
+The interpreter saves 7 fields as a tuple before applying `with`:
+```rust
+(with_document, input, data, processed, processed_paths, with_functions, rule_values)
+```
+
+After applying overrides:
+- `self.processed` is cleared (forces re-evaluation with new context)
+- `self.rule_values` is cleared
+- The expression is evaluated
+- All 7 fields are restored
+
+**Function overrides**:
+- `FunctionModifier::Value(v)` — replace function with constant
+- `FunctionModifier::Function(path)` — replace with another function
+
+## Cycle Detection
+
+The interpreter tracks `active_rules` (a stack of currently-evaluating rules).
+If the same rule appears twice in the stack, a cycle is detected and an error
+is raised with a "depends on" chain for debugging.
+
+## Destructuring Plans
+
+The interpreter executes pre-computed `DestructuringPlan`s for pattern matching
+in assignments and `some...in` bindings:
+
+- `DestructuringPlan::Var` — bind to variable
+- `DestructuringPlan::Ignore` — wildcard `_`
+- `DestructuringPlan::EqualityValue` — match against literal
+- `DestructuringPlan::Array` — destructure array elements
+- `DestructuringPlan::Object` — destructure object fields
+
+Plans are computed at compile time by `src/compiler/destructuring_planner/`.
+
+## Performance-Critical Paths
+
+- **Loop variable caching** (`loop_var_values`): avoids re-evaluating loop
+  expressions on each iteration
+- **Builtin result caching** (`builtins_cache`): memoizes pure builtin calls
+- **Rule processing tracking** (`processed`): prevents redundant evaluation
+- **Execution timer**: cooperative checking with amortized overhead
+
+## Known TODOs in Code
+
+The interpreter has ~15 TODO comments indicating areas of active development:
+- Recursive calls with different values for same expression
+- Type coercion behavior verification
+- With modifier optimization (delay state restore)
+- Variable lookup timing questions
+- Copy optimization for paths
+
+These indicate areas where the code is known to be evolving. Extra care
+is needed when modifying near these comments.
+
+## Connection to RVM
+
+Both the interpreter and RVM:
+- Use the same `BUILTINS` registry
+- Share the `Value` type
+- Use the same `CompiledPolicyData` (schedules, hoisted loops)
+- Produce the same results for the same inputs (semantic equivalence)
+
+When implementing features, they must work in **both** execution paths.

--- a/docs/knowledge/language-extension-guide.md
+++ b/docs/knowledge/language-extension-guide.md
@@ -1,0 +1,199 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Language Extension Guide
+
+How to add new policy languages to regorus. Read this when implementing
+support for a new policy language or modifying the language extension
+architecture.
+
+## Current Architecture
+
+Regorus supports multiple policy languages through `src/languages/`:
+
+```
+src/languages/
+  azure_policy/     JSON-based declarative constraints → RVM bytecode
+  azure_rbac/       Condition expression strings → direct interpretation
+  rego/             Rego source → RVM bytecode (via core compiler)
+```
+
+Each language has its own:
+- **Parser**: language-specific syntax → AST
+- **AST types**: language-specific node types with Span tracking
+- **Compilation or interpretation**: AST → RVM bytecode OR direct evaluation
+- **Feature flag**: compile-time opt-in
+
+### No Shared Trait (Yet)
+
+There is **no common trait** defining language behavior. Each language
+provides its own entry points:
+
+- Azure Policy: `parser::parse_policy_rule()` → `compiler::compile_policy_rule()`
+- Azure RBAC: `parser::parse_condition_expression()` → `ConditionInterpreter::evaluate_str()`
+- Rego: integrated into the core `Engine` via `Lexer → Parser → Interpreter/RVM`
+
+This is an adapter pattern — each language adapts to the shared infrastructure
+in its own way. A formal trait may be introduced as more languages are added.
+
+### Two Execution Strategies
+
+**Strategy 1: Compile to RVM** (Azure Policy, Rego)
+- Parse to language-specific AST
+- Compile to shared `Program` (RVM bytecode)
+- Execute on the shared VM
+- Benefits: shared optimization, serialization, instruction budget enforcement
+
+**Strategy 2: Direct interpretation** (Azure RBAC)
+- Parse to language-specific AST
+- Evaluate directly with a language-specific interpreter
+- Benefits: simpler for expression-oriented languages, no compilation overhead
+
+## Adding a New Language
+
+### Step 1: Feature Flag
+
+```toml
+# Cargo.toml
+[features]
+my_language = ["dep:optional-dep-if-needed"]
+```
+
+### Step 2: Module Structure
+
+```
+src/languages/my_language/
+  mod.rs            Module root, public exports
+  ast/              Language-specific AST types
+    mod.rs          Node types with Span tracking
+  parser/           Language-specific parser
+    mod.rs          Entry point: parse() → AST
+  compiler/         If compiling to RVM (Strategy 1)
+    mod.rs          compile() → Rc<Program>
+  interpreter.rs    If direct interpretation (Strategy 2)
+  builtins/         Language-specific builtin functions (if any)
+```
+
+### Step 3: Register in `src/lib.rs`
+
+```rust
+pub mod languages {
+    #[cfg(feature = "my_language")]
+    pub mod my_language;
+    // ... existing languages
+}
+```
+
+### Step 4: Integration Points
+
+**If compiling to RVM:**
+- Produce a `Program` struct (same as Rego/Azure Policy)
+- Populate metadata with language identifier
+- The shared VM executes the program
+- Benefits from instruction budget, time limits, memory limits
+
+**If direct interpretation:**
+- Implement an interpreter that evaluates against provided context
+- Must enforce resource limits manually (time, memory)
+- Must handle errors consistently with other languages
+
+### Step 5: Engine Integration
+
+Add methods to `Engine` (feature-gated) for loading and evaluating the
+new language:
+
+```rust
+#[cfg(feature = "my_language")]
+pub fn add_my_language_policy(&mut self, source: String) -> Result<()> {
+    let ast = languages::my_language::parser::parse(&source)?;
+    let program = languages::my_language::compiler::compile(&ast)?;
+    // ... integrate with engine
+    Ok(())
+}
+```
+
+## Shared Infrastructure
+
+New languages can reuse:
+
+| Component | Location | What it provides |
+|-----------|----------|-----------------|
+| **Value type** | `src/value.rs` | Shared data representation |
+| **Number type** | `src/number.rs` | High-precision arithmetic |
+| **RVM** | `src/rvm/` | Bytecode execution engine |
+| **Builtins** | `src/builtins/` | Shared builtin functions |
+| **Span** | `src/ast.rs` | Source location tracking |
+| **Limits** | `src/utils/limits/` | Time, memory, execution limits |
+| **Cache** | `src/cache.rs` | LRU caching for compiled patterns |
+| **Engine** | `src/engine.rs` | Policy management, data/input handling |
+
+## Design Considerations for New Languages
+
+### AST Design
+
+- Every node should carry a `Span` for error reporting
+- Use `Ref<T>` (Rc-based) for shared ownership
+- Keep AST types in a dedicated `ast/` module
+
+### Parser Design
+
+- Recursive descent is the standard pattern in regorus
+- Enforce depth limits (default 32) to prevent stack overflow
+- Check memory limits during parsing
+- Track line/column for error messages
+
+### Compilation Design
+
+If targeting the RVM:
+- Allocate registers for intermediate values
+- Use the literal table for constants
+- Define entry points for each evaluatable unit
+- Populate metadata (language name, version, etc.)
+- Run `validate_limits()` on the generated program
+
+### Error Design
+
+- Use `thiserror` for language-specific error types
+- Include source location (Span) in all errors
+- Don't leak sensitive information in error messages
+- Consider error recovery for better diagnostics
+
+### Testing
+
+- Create YAML test cases in `tests/` or language-specific test directory
+- Cover: normal operation, edge cases, error conditions, resource limits
+- Verify against reference implementation if one exists
+
+## Future Directions
+
+### Language Server Protocol (LSP)
+
+The AST and Span infrastructure supports building language servers:
+- **Completion**: AST traversal for scope-aware suggestions
+- **Diagnostics**: Parser/compiler errors with source locations
+- **Go to definition**: Span tracking enables precise navigation
+- **Hover**: AST node identification for type/documentation info
+
+### Linters and Analyzers
+
+The compilation pipeline enables static analysis:
+- **Scheduler output**: dependency analysis for unused variables
+- **Scope analysis**: detect shadowing, unused imports
+- **Type inference**: Value type tracking through expressions
+- **Complexity analysis**: rule depth, statement count, loop nesting
+
+### Partial Evaluation
+
+Not currently implemented but the architecture supports it:
+- The RVM's register-based design could track symbolic values
+- The scheduler's dependency analysis identifies independent subexpressions
+- Compilation could produce partially-evaluated programs with "holes"
+- Design principle: keep evaluation logic pure and side-effect-free
+
+### Causality Tracking
+
+Understanding WHY a policy decision was made:
+- The RVM's instruction-level execution could log decision paths
+- The interpreter's context stack tracks which rules contributed
+- Frame-level tracing in suspendable mode provides execution history
+- Coverage tracking (`coverage` feature) already records evaluated expressions

--- a/docs/knowledge/policy-evaluation-security.md
+++ b/docs/knowledge/policy-evaluation-security.md
@@ -1,0 +1,201 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Policy Evaluation Security
+
+Deep knowledge about security properties, DoS protection, resource limits,
+and input validation in regorus. Read this before modifying evaluation paths,
+parsers, or resource management.
+
+## Threat Model
+
+Regorus evaluates **untrusted policy code** against **untrusted data**. Both
+may be adversarial. The engine must:
+
+1. **Always terminate** — no infinite loops, no unbounded recursion
+2. **Bound resource usage** — memory, CPU time, instruction count
+3. **Return correct results** — a wrong result is a security vulnerability
+4. **Never crash** — panics in daemon mode crash the service
+5. **Not leak information** — error messages must not expose sensitive data
+
+## Resource Limit Enforcement
+
+### Instruction Budget (RVM)
+
+The primary defense against computation-based DoS:
+
+- **Default**: 25,000 instructions (`src/rvm/vm/machine.rs`)
+- **Enforcement**: checked every iteration in the execution loop
+- **Error**: `VmError::InstructionLimitExceeded`
+- **Configurable**: `set_max_instructions(limit)`
+
+### Execution Time Limits
+
+Wall-clock enforcement via `ExecutionTimer` (`src/utils/limits/time.rs`):
+
+- **Cooperative checking** — the timer is checked periodically, not preemptively
+- **Amortized overhead** — accumulates work units before reading the clock
+  to avoid syscall overhead
+- **Suspended time excluded** — `resume_from_elapsed()` preserves elapsed time
+  across VM suspensions, so only active computation counts
+- **Per-instance override** — each VM can set its own timer config
+- **Error**: `VmError::TimeLimitExceeded`
+
+### Memory Limits
+
+Global memory tracking via `src/utils/limits/memory.rs`:
+
+- **Global atomic limit** — `GLOBAL_MEMORY_LIMIT: AtomicU64`
+- **Throttled checking** — dual strategy to avoid contention:
+  - Stride-based: check every 16 iterations
+  - Delta-based: check when 32 KiB has been allocated since last check
+- **Per-thread flushing** — auto-flush at 1 MiB threshold
+- **Enforcement points**: Value construction, deserialization, parsing
+- **Error**: `VmError::MemoryLimitExceeded`
+
+The `allocator-memory-limits` feature uses mimalloc to enforce at the allocator
+level.
+
+## Input Validation
+
+### Policy Source (`src/lexer.rs`)
+
+Rego source is validated during lexing with configurable limits:
+
+| Limit | Default | Purpose |
+|-------|---------|---------|
+| `max_col` | 1,024 chars | Lines exceeding this are likely minified/attack code |
+| `max_file_bytes` | 1 MiB | Prevents memory exhaustion from huge files |
+| `max_lines` | 20,000 | Prevents excessive parsing time |
+
+Memory limit is also checked after each logical chunk during lexing.
+
+### Parser Depth
+
+The parser enforces expression nesting depth:
+
+- **Default**: `MAX_EXPR_DEPTH = 32` (`src/parser.rs`)
+- Prevents stack overflow from deeply nested expressions like `(((((...)))))`
+- Returns error, not panic
+
+### JSON/YAML Data
+
+Data added via `add_data()` must be an object (checked by `engine.rs`).
+Value construction during deserialization checks memory limits at each node.
+
+### RVM Programs
+
+Compiled programs validated by `validate_limits()` (`src/rvm/program/core.rs`):
+
+| Resource | Limit |
+|----------|-------|
+| Instructions | 65,535 |
+| Literals | 65,535 |
+| Rules | 4,000 |
+| Entry points | 1,000 |
+| Source files | 256 |
+| Builtins | 512 |
+| Path depth | 32 |
+
+These prevent adversarial serialized programs from consuming excessive resources
+during deserialization or execution.
+
+## Recursion Protection
+
+- **Parser**: `MAX_EXPR_DEPTH = 32` for expression nesting
+- **RVM**: `MAX_PATH_DEPTH = 32` for rule path depth
+- **Virtual documents**: `needs_runtime_recursion_check` flag enables detection
+  when `VirtualDataDocumentLookup` instructions are present
+- **Rule evaluation**: processed rules tracked in `self.processed` set to
+  prevent re-evaluation cycles
+
+## DoS via Regular Expressions
+
+Regorus uses the `regex` crate which compiles to a DFA — **no catastrophic
+backtracking**. Protection is layered:
+
+1. DFA-based regex engine (no exponential blowup)
+2. Instruction budget limits total work
+3. Execution time limits bound wall-clock
+4. LRU cache prevents repeated compilation (256 patterns, hard cap 2^16)
+
+## Undefined vs False
+
+**This is a security-critical distinction.** In policy evaluation:
+
+```rego
+allow { input.role == "admin" }
+```
+
+If `input.role` is missing:
+- `input.role == "admin"` → `Undefined` (not `false`)
+- `allow` → `Undefined` (rule body didn't succeed)
+- `not allow` → `true` (because `not Undefined = true`)
+
+A bug that treats `Undefined` as `false` (or vice versa) can change policy
+decisions. Every evaluation path must handle the three-valued logic correctly.
+
+See `docs/knowledge/value-semantics.md` for detailed Undefined propagation rules.
+
+## Supply Chain Security
+
+### Dependency Auditing
+
+The `dependency-audit.yml` workflow runs:
+- **cargo-audit**: checks 6 Cargo.lock files (main + 5 bindings) against
+  RustSec advisories
+- **cargo-deny**: checks 9 manifests for CVEs (advisories) and problematic
+  dependencies (bans)
+- **Schedule**: PRs, main pushes, weekly (Mondays 6 AM), manual dispatch
+
+### Dependency Management
+
+- **Pinned action SHAs**: most GitHub Actions references use full commit SHAs
+  rather than mutable tags — prevents supply chain attacks via tag mutation.
+  Some workflows (e.g., `dependency-audit.yml`, `miri.yml`) still use tag-based
+  refs; prefer SHA pins when adding or updating action references
+- **Locked dependencies**: `Cargo.lock` committed, `cargo fetch --locked` /
+  `--frozen` in CI ensures reproducible builds
+- **Dependabot**: automated weekly updates for Cargo, GitHub Actions, Maven,
+  NuGet, pip, npm, bundler, Go
+- **Minimal dependency surface**: prefer `core`/`alloc` over external crates
+
+### Spectre Mitigation
+
+On Windows (MSVC), the optional `msvc_spectre_libs` dependency links with
+Spectre-mitigated CRT and libraries.
+
+## Panic Safety
+
+The 80+ deny lints in `src/lib.rs` exist not just for style — they prevent
+panics at compile time:
+
+| Denied | Why |
+|--------|-----|
+| `clippy::unwrap_used` | `.unwrap()` panics on `None`/`Err` |
+| `clippy::expect_used` | `.expect()` panics on `None`/`Err` |
+| `clippy::indexing_slicing` | `vec[i]` panics on out-of-bounds |
+| `clippy::arithmetic_side_effects` | `a + b` can overflow and panic |
+| `clippy::panic` | Explicit `panic!()` |
+| `clippy::unreachable` | Explicit `unreachable!()` |
+| `clippy::todo` | Explicit `todo!()` |
+
+In daemon mode, **any panic is a service crash**. The deny lints are the first
+line of defense. The FFI layer's `with_unwind_guard()` is the second — it
+catches panics and poisons the engine (see `docs/knowledge/ffi-boundary.md`).
+
+But panic containment is a last resort. The goal is zero panics in all code
+paths, including error paths, resource exhaustion, and adversarial input.
+
+## Security Review Checklist
+
+When reviewing code for security:
+
+1. **Undefined handling** — does the code correctly distinguish Undefined from false?
+2. **Resource limits** — does new code respect instruction budget, time, memory?
+3. **Input validation** — is untrusted input validated before use?
+4. **Panic paths** — can any code path panic (overflow, indexing, unwrap)?
+5. **Error messages** — do errors avoid leaking policy content or data?
+6. **Recursion** — is recursion bounded?
+7. **Allocation** — can adversarial input cause unbounded allocation?
+8. **Cache behavior** — can cache be poisoned or exhausted?

--- a/docs/knowledge/rego-compiler.md
+++ b/docs/knowledge/rego-compiler.md
@@ -1,0 +1,286 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Rego Compiler
+
+Deep knowledge about the Rego → RVM bytecode compiler in
+`src/languages/rego/compiler/`. Read this before modifying rule compilation,
+expression codegen, register allocation, or optimization passes.
+
+See also `compilation-pipeline.md` for the scheduler and loop hoisting stages
+that feed into this compiler.
+
+## Module Structure
+
+```
+src/languages/rego/compiler/
+  mod.rs               Compiler struct, scope management, register allocation
+  core.rs              Variable resolution, register helpers, instruction emission
+  program.rs           finish() — default rules, rule info construction, metadata
+  rules.rs             Worklist algorithm, per-definition rule compilation
+  queries.rs           Statement compilation, loop hoisting integration
+  expressions.rs       Expression dispatch, recursive compilation
+  references.rs        Chained reference parsing (obj.a[x].b[y])
+  function_calls.rs    Builtin vs. user-defined function dispatch
+  loops.rs             `every` quantifier, loop mode handling
+  comprehensions.rs    Array/Set/Object comprehension compilation
+  destructuring.rs     Function parameter binding/validation
+  error.rs             Error types with span tracking
+```
+
+## Worklist Algorithm
+
+Rule compilation uses a worklist (depth-first queue) rather than
+recursive descent. This provides three benefits:
+
+1. **Dependency ordering** — rules are compiled in reference order
+2. **Recursion detection** — a call stack tracks in-progress rules
+3. **Deduplication** — already-compiled rules are skipped
+
+```
+while worklist not empty:
+    pop (rule_path, call_stack) from worklist
+    if rule_path in call_stack → compile-time recursion error
+    if rule_path already compiled → skip
+    push rule_path onto call_stack
+    compile all definitions of rule_path
+    mark rule as compiled
+```
+
+When compiling a rule body encounters `CallRule` to another rule, that
+target rule is pushed onto the worklist. This ensures rules are compiled
+in call order.
+
+## Variable Resolution
+
+The compiler resolves variable names through a priority chain
+(`core.rs`):
+
+```
+1. "input"  → emit LoadInput (cached per rule definition)
+2. "data"   → emit LoadData (cached per rule definition)
+3. scope    → use bound register from current scope
+4. fallback → treat as rule call: data.{package}.{name}
+```
+
+**Input/data caching**: `LoadInput` and `LoadData` are emitted at most
+once per rule definition. The cached register is reused for subsequent
+references. The cache is reset between definitions to prevent stale state.
+
+## Register Allocation
+
+### Three-Tier Strategy
+
+**Dispatch window** — initial registers for entry point dispatch and
+temporary work. Sized by `dispatch_window_size`.
+
+**Per-rule window** — max registers within any single rule definition.
+Register 0 is always the result accumulator. The VM allocates a fixed
+frame per rule based on `max_rule_window_size`.
+
+**Per-definition reset** — `register_counter` resets to 0 at each
+definition start. This minimizes frame size and enables tail calls.
+
+### Special Registers
+
+| Register | Purpose |
+|----------|---------|
+| 0 | Rule result accumulator |
+| `current_input_register` | Cached `LoadInput` (per definition) |
+| `current_data_register` | Cached `LoadData` (per definition) |
+| 0..N-1 (functions) | Function parameter bindings |
+
+**Limit**: u8 register counter (max 255). The compiler asserts
+`register_counter < 255`.
+
+## Expression Compilation
+
+Each `Expr` variant maps to one or more RVM instructions:
+
+| Expr | Instructions | Notes |
+|------|-------------|-------|
+| Literal (Num/Str/Bool) | `Load` | Literals go to literal table |
+| `true`/`false`/`null` | `LoadTrue`/`LoadFalse`/`LoadNull` | Special-cased |
+| Var (in scope) | — | Reuse bound register |
+| Var (unresolved) | `CallRule` | Treat as rule reference |
+| RefDot | `IndexLiteral` | Literal key optimization |
+| RefBrack | `Index` or loop | Depends on bound/unbound index |
+| Chained ref | `ChainedIndex` | `obj.a[x].b[y]` → single instruction |
+| ArithExpr | `Add`/`Sub`/`Mul`/`Div`/`Mod` | |
+| BoolExpr | `Eq`/`Ne`/`Lt`/`Le`/`Gt`/`Ge` | |
+| Not | `Not` | |
+| Call (builtin) | `BuiltinCall` | Via builtin_call_params table |
+| Call (user) | `FunctionCall` | Via function_call_params table |
+| ArrayCompr | `ComprehensionBegin..Yield..End` | Mode: Array |
+| SetCompr | `ComprehensionBegin..Yield..End` | Mode: Set |
+| ObjectCompr | `ComprehensionBegin..Yield..End` | Mode: Object |
+| Every | `LoopStart { mode: Every }` | Quantifier loop |
+| SomeIn | `LoopStart` | Iteration with binding |
+| UnaryMinus | `Sub` (0 - x) | |
+
+### Chained References
+
+Multi-level property access like `input.request.headers["content-type"]`
+compiles to a single `ChainedIndex` instruction with parameters:
+
+```rust
+ChainedIndexParams {
+    dest: u8,
+    root: ChainedIndexRoot,     // Var or Expr
+    components: Vec<Component>, // Field(literal_idx) or Expr(register)
+}
+```
+
+This avoids emitting multiple `Index` instructions and intermediate
+registers.
+
+## Rule Type Compilation
+
+### Complete Rules
+
+```rego
+allow := input.admin == true
+```
+
+- Body compiled as normal statements
+- Success: `RuleReturn {}` (stores result in register 0)
+- **Static value optimization**: if all definitions yield the same constant,
+  the rule gets `early_exit_on_first_success = true` — VM stops after
+  first successful definition
+
+### Partial Set Rules
+
+```rego
+ports contains p if { ... }
+```
+
+- Emit `ComprehensionYield { value_reg, key_reg: None }`
+- Result register accumulates a set of all yielded values
+
+### Partial Object Rules
+
+```rego
+people[name] = age if { ... }
+```
+
+- Emit `ComprehensionYield { value_reg, key_reg: Some(k) }`
+- Result register accumulates key-value pairs
+
+### Functions
+
+```rego
+f(x, y) := x + y
+```
+
+- Parameters bound to registers 0..N-1 before body compilation
+- `DestructuringSuccess {}` emitted after parameter validation
+- Consistent parameter count enforced across all definitions
+- After compilation, `FunctionInfo` recorded with param names
+
+## Comprehension Compilation
+
+All comprehensions follow the same pattern:
+
+```
+ComprehensionBegin { mode, collection_reg, body_start, end }
+  [body: hoisted loops → statements → ComprehensionYield]
+ComprehensionEnd {}
+```
+
+Modes: `Array`, `Set`, `Object`. The VM creates the appropriate
+collection type and appends each yielded value.
+
+**Context stack**: the compiler pushes a comprehension context to
+track that yield should go to the comprehension (not the rule).
+
+## Optimization Passes
+
+### Constant Folding
+
+`try_eval_const()` evaluates pure expressions at compile time:
+- Array/Set/Object literals with all-constant elements
+- Index operations on constant collections
+- Result stored in literal table, emitted as `Load`
+
+### Static Value Detection
+
+After compiling all definitions of a complete rule, the compiler checks
+if every definition yields the same static value. If so:
+- `early_exit_on_first_success = true`
+- VM stops after first successful definition body
+- Common pattern: `default allow := false` + `allow := true { ... }`
+
+### Literal Key Optimization
+
+`obj["literal"]` compiles to `IndexLiteral { literal_idx }` instead of
+loading the string into a register and using `Index`. Avoids a register
+allocation and a `Load` instruction.
+
+### Lazy Builtin Indexing
+
+Builtins are assigned indices only when first used during compilation.
+The builtin info table contains only actually-referenced builtins,
+kept in deterministic order (BTreeMap).
+
+## Compile-Time Safety
+
+### Recursion Detection
+
+The worklist's call stack detects compile-time recursion:
+```
+Rule A calls Rule B calls Rule A → error
+```
+This prevents infinite compilation loops for mutually recursive rules.
+
+### Register Overflow
+
+`alloc_register()` asserts `register_counter < 255`. If a rule body
+requires more than 255 registers, compilation fails rather than silently
+wrapping.
+
+## Program Output
+
+The compiler produces `Arc<Program>` containing:
+
+```rust
+struct Program {
+    instructions: Vec<Instruction>,        // Bytecode stream
+    literals: Vec<Value>,                  // Constant value table
+    builtin_info_table: Vec<BuiltinInfo>,  // Referenced builtins
+    rule_infos: Vec<RuleInfo>,             // Rule metadata
+    entry_points: IndexMap<String, usize>, // Rule path → instruction offset
+    instruction_data: InstructionData,     // Extended params tables
+    span_infos: Vec<SpanInfo>,             // Source mapping (1:1 with instructions)
+}
+```
+
+Every instruction has a corresponding `SpanInfo` for source mapping,
+enabling debugging and IDE integration.
+
+## Key Invariants
+
+1. **Register 0 = result** — every rule's result is in register 0
+2. **Input/data cache reset per definition** — prevents stale references
+3. **Worklist ordering** — rules compiled in call-graph order
+4. **Instruction ↔ SpanInfo 1:1** — every instruction has source location
+5. **Literal table is append-only** — indices are stable after emission
+
+## Common Pitfalls
+
+1. **Scope nesting** — comprehensions and `every` push new scopes.
+   Variables bound in inner scopes are not visible in outer scopes.
+
+2. **Hoisted loop coordination** — the compiler must query the hoisting
+   table for each statement to know which loops to emit. Missing a
+   hoisted loop causes incorrect variable binding at runtime.
+
+3. **Multi-definition rules** — each definition resets registers but
+   shares the same `RuleInfo`. The `definitions` array in `RuleInfo`
+   records instruction ranges for each definition.
+
+4. **Function parameter count** — all definitions of a function must
+   have the same number of parameters. The compiler enforces this.
+
+5. **Builtin vs user function** — the compiler must distinguish builtin
+   calls (which use `BuiltinCall` with the builtin registry) from user
+   function calls (which use `FunctionCall` with the rule index).

--- a/docs/knowledge/rego-semantics.md
+++ b/docs/knowledge/rego-semantics.md
@@ -1,0 +1,230 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Rego Semantics
+
+Deep knowledge about how regorus evaluates Rego policies. Read this before
+modifying `src/interpreter.rs`, `src/scheduler.rs`, `src/compiler/`, or
+any evaluation-related code.
+
+## Evaluation Model
+
+Regorus is a **compile-then-execute** engine. Key passes:
+
+```
+Source → Lexer → Parser → AST → Compiler (scheduling, destructuring, loop hoisting) → Execution
+```
+
+The compiler pre-computes:
+- **Destructuring plans**: how to bind variables from patterns
+- **Schedules**: statement execution order within rule bodies
+- **Loop hoisting**: which iterations can be computed at compile time
+
+Runtime evaluation is then straightforward — no runtime planning.
+
+## Rule Evaluation
+
+### Rule Types
+
+**Complete rules** — produce a single value:
+```rego
+allow = true { input.role == "admin" }
+```
+
+**Partial rules** — can have multiple bodies, first success wins:
+```rego
+allow { input.role == "admin" }
+allow { input.role == "superuser" }
+```
+Bodies are evaluated in order. When one succeeds, remaining bodies are skipped.
+
+**Default rules** — fallback when no rule produces a value:
+```rego
+default allow = false
+```
+Default rules are explicitly skipped during normal rule evaluation. They fire
+only when the path is `Undefined` and no complete rule exists.
+
+**Precedence**: `initial data > evaluated rules > default rules`
+
+### Rule Caching
+
+Evaluated rules are tracked in `self.processed` set to prevent re-evaluation.
+Once a rule has been evaluated for a given context, it won't be re-evaluated
+unless the context changes (e.g., via `with` keyword).
+
+## Unification and Destructuring
+
+Regorus does **NOT use a traditional unification algorithm**. Instead:
+
+1. The **compiler** analyzes patterns and generates `DestructuringPlan`s
+2. At runtime, `execute_destructuring_plan()` matches values against patterns
+3. Returns `true` (match succeeded, variables bound) or `false` (no match)
+
+This is more like pattern matching than Prolog-style unification. There is no
+occurs check, no variable-to-variable binding chains.
+
+## Backtracking
+
+Backtracking in regorus is **limited and explicit** — it only occurs with
+`some...in` expressions:
+
+```rego
+some x in collection
+```
+
+The backtracking mechanism:
+1. Save current scope
+2. Iterate over the collection
+3. For each element, bind variables and evaluate remaining statements
+4. If remaining statements fail, restore scope and try next element
+5. Succeed if any element leads to successful evaluation
+
+**There is no implicit backtracking** in other contexts. Statements in a rule
+body execute sequentially — if one fails, the entire rule body fails (no
+trying alternatives for previous statements).
+
+## Undefined Propagation in Evaluation
+
+### Boolean and Comparison Operations
+
+```
+Undefined <op> anything  →  Undefined
+anything <op> Undefined  →  Undefined
+```
+
+This applies to all binary operations: `==`, `!=`, `<`, `>`, `<=`, `>=`,
+`+`, `-`, `*`, `/`, `%`, `&`, `|`.
+
+### Negation (the subtle case)
+
+```
+not true      →  false
+not false     →  true
+not Undefined →  true
+```
+
+`not Undefined` is `true` because negating "this expression has no value"
+means "the condition is not met" which is truthy. This is correct OPA
+semantics.
+
+### Reference Chains
+
+```rego
+x = input.a.b.c
+```
+
+If `input.a` exists but `input.a.b` doesn't, the entire reference returns
+`Undefined`. The interpreter navigates the path and returns `Undefined` at the
+first missing component.
+
+### Collection Literals
+
+```rego
+arr = [1, x, 3]   # If x is Undefined, arr is Undefined (not [1, 3])
+```
+
+Any `Undefined` element poisons the entire collection literal. This is not
+intuitive but matches OPA semantics.
+
+### Builtin Arguments
+
+```rego
+count(x)   # If x is Undefined, result is Undefined
+```
+
+If any argument to a builtin is `Undefined`, the result is `Undefined`. The
+function is never called.
+
+### Rule Body Statements
+
+When a statement in a rule body evaluates to `Undefined` or `false`, the
+rule body fails. Statements must succeed sequentially:
+
+```rego
+allow {
+    input.role == "admin"    # If Undefined → body fails here
+    input.active == true     # Never reached
+}
+```
+
+## Virtual Documents (Rules as Data)
+
+Rules materialize into the `data` object. When code references `data.pkg.rule`,
+the interpreter:
+
+1. Checks if the path has initial data (from `add_data()`)
+2. If not, looks for rules that define that path
+3. Evaluates those rules (if not already cached)
+4. Returns the result
+
+`ensure_rule_evaluated()` is the trigger — it's called during path navigation
+when a reference might resolve to a rule-defined value.
+
+## The `with` Keyword
+
+`with` temporarily overrides data, input, or functions during evaluation:
+
+```rego
+x = eval { y = f(1) with f as g }
+```
+
+Implementation pattern (save/modify/restore):
+1. Save current state (data, input, processed rules, rule values, with_functions)
+2. Apply overrides — modify `self.with_document` and related state
+3. Clear `self.processed` to allow re-evaluation with new overrides
+4. Evaluate the expression
+5. Restore original state
+
+**Function override types:**
+- `FunctionModifier::Value(v)` — replace function with a constant value
+- `FunctionModifier::Function(path)` — replace function with another function
+
+## Comprehensions
+
+All comprehensions follow the same pattern:
+
+1. Push new context with `output_expr` and collection type
+2. Evaluate the query (generates solutions)
+3. For each solution, evaluate `output_expr` and add to context's collection
+4. Pop context and return accumulated collection
+
+**Array comprehension**: `[expr | query]` → ordered array of expr values
+**Set comprehension**: `{expr | query}` → set of expr values
+**Object comprehension**: `{key: value | query}` → object of key-value pairs
+
+## Scheduling
+
+The scheduler (`src/scheduler.rs`) determines statement execution order within
+rule bodies. This is a **compile-time** optimization that:
+
+1. Analyzes variable dependencies between statements
+2. Orders statements to minimize wasted work
+3. Moves ground-truth checks (constants, type checks) before expensive iterations
+4. Hoists loop-invariant computations
+
+The schedule is pre-computed and stored — the interpreter follows it directly.
+
+## OPA Conformance
+
+Regorus targets faithful OPA semantics. The conformance suite (`tests/opa.rs`)
+runs the official OPA test cases. Key areas where conformance matters:
+
+- **Undefined propagation** — must match OPA exactly
+- **Error messages** — builtin error messages are compared literally
+- **Type coercion** — number handling, string comparison
+- **Rule indexing** — which rules fire for which inputs
+- **Comprehension behavior** — ordering, deduplication
+
+When behavior differs from OPA, it's a bug unless documented as an intentional
+extension (gated behind `rego-extensions` feature).
+
+## Common Pitfalls
+
+1. **Treating Undefined as false** — see value-semantics.md for the full story
+2. **Forgetting `not Undefined = true`** — the most common subtle bug
+3. **Collection literal with Undefined element** — entire collection becomes Undefined
+4. **Rule body short-circuit** — first failing statement stops the body
+5. **Default rule precedence** — defaults only fire when path is truly Undefined
+6. **`with` scope** — overrides only apply to the expression, not siblings
+7. **Virtual document evaluation order** — rules may evaluate lazily

--- a/docs/knowledge/rvm-architecture.md
+++ b/docs/knowledge/rvm-architecture.md
@@ -1,0 +1,200 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: RVM Architecture
+
+Deep knowledge about the Rego Virtual Machine. Read this before modifying
+anything in `src/rvm/`. Also see `docs/rvm/architecture.md`,
+`docs/rvm/instruction-set.md`, and `docs/rvm/vm-runtime.md`.
+
+## Overview
+
+The RVM compiles Rego policies to register-based bytecode with fixed-width
+32-bit instructions, then executes them in a virtual machine:
+
+```
+Policy source → Lexer → Parser → AST → Compiler → Program (bytecode) → VM → Value
+```
+
+This is the **strategic execution path** — new optimization and feature work
+focuses on the RVM, not the tree-walking interpreter.
+
+## Directory Structure
+
+```
+src/rvm/
+  instructions/       Instruction definitions (fixed-width 32-bit opcodes)
+  program/
+    core.rs           Program struct — instructions, literals, entry points, rule info
+    serialization/    Binary and JSON format implementations
+    recompile.rs      Recompilation from partial programs
+  vm/
+    machine.rs        RegoVM — registers, stacks, execution state
+    execution.rs      Run-to-completion and suspendable execution loops
+    dispatch.rs       Instruction dispatch
+    loops.rs          Loop iteration (Any, Every, ForEach modes)
+    comprehension.rs  Set/array/object comprehension builders
+    rules.rs          Rule evaluation, caching, call stacks
+    virtual_data.rs   Virtual document lookup and caching
+    state.rs          Register window pooling and state management
+    errors.rs         VmError — strongly typed VM errors
+  tests/              RVM-specific test suites
+```
+
+## Two Execution Modes
+
+### Run-to-Completion
+
+The VM executes instructions sequentially until the program completes or
+errors. No suspension. This is the **fast path** for synchronous policy
+evaluation. Most production use cases.
+
+### Suspendable
+
+The VM can suspend mid-execution and be resumed later:
+
+| Reason | Use case |
+|--------|----------|
+| **HostAwait** | Program needs external data from the host |
+| **Breakpoint** | Debugging support |
+| **SingleStep** | Instruction-by-instruction execution |
+
+The host calls `vm.resume(value)` to continue after suspension. The VM
+preserves its entire execution state across suspend/resume cycles.
+
+**Important:** `SuspendReason` variants that appear in run-to-completion mode
+trigger `VmError::UnsupportedSuspendInRunToCompletion`.
+
+## Frame Stack
+
+The suspendable mode uses an explicit frame stack (`execution_stack`) with
+frame kinds:
+
+| Frame Kind | Purpose |
+|------------|---------|
+| **Main** | Top-level program execution |
+| **Rule** | Rule body evaluation |
+| **Loop** | Collection iteration (Any, Every, ForEach) |
+| **Comprehension** | Set/array/object comprehension building |
+
+Each frame tracks its own:
+- Program counter (PC)
+- Register window (base + count)
+- Saved caller state (for restoration on frame pop)
+
+Frames are pushed on entry and popped on completion. The frame stack is the
+mechanism that makes suspension possible — the entire execution state is
+captured in the stack.
+
+## Register Window Pooling
+
+The VM reuses register vectors to minimize allocation:
+
+- **Pool**: `state.rs` manages a pool of `Vec<Value>` vectors
+- **Window**: Each frame gets a register window (base offset + count)
+- **Reuse**: When a frame pops, its register vector returns to the pool
+- **Predictable**: Allocation pattern is bounded and deterministic
+
+**Invariant:** New VM features MUST participate in register window pooling.
+Do not allocate fresh Vecs for register storage.
+
+## Instruction Budget
+
+The VM enforces a configurable instruction limit to prevent unbounded execution:
+
+- **Default**: 25,000 instructions (`machine.rs`)
+- **Enforcement**: Checked in the execution loop (`execution.rs`)
+- **Configurable**: `set_max_instructions(limit)` allows any `usize` value
+- **Error**: `VmError::InstructionLimitExceeded` when exceeded
+
+This is the primary defense against denial-of-service via crafted policies.
+All new execution paths must respect this budget — do not add loops or
+recursion that bypass the instruction counter.
+
+## Program Serialization
+
+Compiled programs can be serialized for distribution and cached execution.
+
+### Binary Format (Primary)
+
+Compact, fast deserialization. Used for production distribution of pre-compiled
+policies. Implemented via the `postcard` crate.
+
+### JSON Format (Debugging)
+
+Human-readable. Useful for debugging, tooling, and inspection.
+
+### Artifact Structure
+
+The program has two sections:
+
+**Stable section** (always serializable):
+- Source files, entry points, metadata
+- Rule information, builtin references
+- Sufficient to recompile the execution section
+
+**Execution section** (version-sensitive):
+- Instructions, literals, parameter tables
+- May fail to deserialize on format version mismatch
+
+**Recompilation fallback**: If the execution section can't be deserialized
+(e.g., after a regorus version upgrade), it can be recompiled from the stable
+section. This is handled by `recompile.rs`.
+
+### Program Limits
+
+`validate_limits()` in `program/core.rs` enforces hard bounds:
+
+| Resource | Limit |
+|----------|-------|
+| Instructions | 65,535 |
+| Literals | 65,535 |
+| Rules | 4,000 |
+| Entry points | 1,000 |
+| Source files | 256 |
+| Builtins | 512 |
+| Path depth | 32 |
+
+These limits prevent adversarial programs from consuming excessive resources.
+
+## VmError Pattern
+
+The RVM uses strongly typed errors (`src/rvm/vm/errors.rs`):
+
+```rust
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum VmError {
+    #[error("Execution stopped: exceeded maximum instruction limit of {limit} ...")]
+    InstructionLimitExceeded { limit: usize, executed: usize, pc: usize },
+    // ... 30+ variants
+}
+```
+
+Every error variant includes `pc` (program counter) for debugging. This is the
+reference pattern for strongly typed errors in regorus — new subsystems should
+follow this design.
+
+## Rule Caching
+
+The VM caches rule evaluation results to avoid redundant computation:
+- Rules are identified by index
+- Cache is checked before evaluation
+- Cache size must match rule info count (`VmError::RuleCacheSizeMismatch`)
+
+## Virtual Document Lookup
+
+Virtual documents (rules-as-data) are resolved through `virtual_data.rs`:
+- Paths are navigated through the rule tree
+- Results are cached per-evaluation
+- `needs_runtime_recursion_check` flag enables recursion detection
+
+## Performance Priorities
+
+Optimization focus areas in `src/rvm/vm/`:
+1. **Instruction dispatch** — tight loop, minimal branch overhead
+2. **Register window pooling** — predictable allocation, zero unnecessary allocs
+3. **Rule caching** — avoid redundant evaluation
+4. **Virtual document lookup caching** — avoid redundant path navigation
+5. **Comprehension building** — efficient collection construction
+
+Profile with `benches/` (Criterion) before optimizing.

--- a/docs/knowledge/telemetry-and-diagnostics.md
+++ b/docs/knowledge/telemetry-and-diagnostics.md
@@ -1,0 +1,193 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Telemetry and Diagnostics
+
+## Overview
+
+regorus evaluates authorization and compliance policies at Azure scale. When a
+policy returns an unexpected result, operators need to understand **why** —
+without reading regorus source code, without reproducing the exact environment,
+and often under time pressure during an incident.
+
+This knowledge file captures the telemetry and diagnostics architecture: what
+exists today, what's planned, and the design principles that guide diagnostic
+features.
+
+## Design Principles
+
+1. **Every decision must be explainable** — "policy X denied request Y because
+   condition Z at policy.rego:42 evaluated to Undefined"
+2. **Errors trace back to policy source** — file, line, column, rule name
+3. **Structured over unstructured** — machine-parseable diagnostics enable tooling
+4. **Zero-cost when off** — diagnostics must not affect evaluation performance
+   when not enabled (compile-time or runtime gating)
+5. **Cloud-scale observability** — span-based tracing that integrates with
+   distributed tracing systems (OpenTelemetry)
+6. **Defense in depth** — no secrets in diagnostics (policy content, input data)
+
+## Current State
+
+### Source Location Tracking (Strong)
+
+Every syntax element carries a `Span` with source file, line, column, and byte
+offset. The `Source::message()` method produces formatted error output:
+
+```
+error: policy.rego:42:5
+  |
+  42 | input.role == "admin"
+  |     ^^^^^^^^^ type mismatch: expected string, got number
+```
+
+This works for **parse and compile errors**. Evaluation errors have partial
+coverage — some carry Span, others lose it during execution.
+
+### Error Types (Comprehensive but Fragmented)
+
+Multiple error hierarchies exist across subsystems:
+
+| Subsystem | Error type | Location tracking |
+|-----------|-----------|-------------------|
+| Lexer/Parser | `Span`-annotated errors | ✅ file:line:col |
+| Rego compiler | `SpannedCompilerError` | ✅ file:line:col |
+| RVM execution | `VmError` (40+ variants) | ⚠️ program counter only |
+| Schema validation | `ValidationError` (20+ variants) | ⚠️ JSON path only |
+| Azure RBAC | `ConditionEvalError` | ⚠️ limited |
+| Interpreter | `anyhow::Error` with context | ⚠️ varies |
+
+**Gap**: RVM errors have a program counter (`pc`) but no reverse mapping to
+policy source location. This is the most critical diagnostic gap — when the VM
+reports `InstructionLimitExceeded at pc=1234`, operators cannot trace back to
+which policy rule was executing.
+
+### Trace Builtin (Exists, Not Exported)
+
+The `trace(msg)` builtin accumulates messages internally via
+`Interpreter::set_traces(bool)`. However:
+- **No public API** to retrieve traces from `Engine`
+- Traces are string-only (not structured)
+- No trace correlation with evaluation steps
+- No RVM equivalent of trace collection
+
+### Print Gathering
+
+`Engine::take_prints()` retrieves accumulated `print()` output. This works
+but is designed for debugging by policy authors, not for operational telemetry.
+
+### Limit Enforcement
+
+Resource limits produce diagnostic VmError variants:
+- `InstructionLimitExceeded { pc, limit }`
+- `MemoryLimitExceeded { usage, limit }`
+- `TimeLimitExceeded { elapsed, limit }`
+
+These include numeric context but not evaluation context (which rule, which
+input).
+
+### Coverage Tracking (Internal Only)
+
+Feature-gated coverage tracking exists in the interpreter but has no public
+API. This could be the foundation for evaluation path diagnostics.
+
+## Planned Capabilities
+
+### Phase 1: Error Traceability (Foundation)
+
+- **PC-to-source mapping**: RVM bytecode instructions should carry source
+  location metadata, enabling reverse mapping from `pc` to policy:line:col
+- **Export trace builtin**: Expose `traces` through the public `Engine` API
+- **Structured errors**: Migrate key errors to structured types with
+  `serde::Serialize` for machine consumption
+- **Evaluation context in limits**: When limits are hit, include the rule name
+  and approximate policy location
+
+### Phase 2: Evaluation Explanation
+
+- **Decision attribution**: "rule `allow` returned true because all conditions
+  in the rule body at policy.rego:15-28 were satisfied"
+- **Undefined explanation**: "rule `allow` was Undefined because `input.role`
+  at policy.rego:18 was not present in the input document"
+- **Causality tracking**: integration with the planned causality system
+  (see `causality-and-partial-eval.md`)
+- **Coverage export**: public API for evaluation path coverage data
+
+### Phase 3: Cloud-Scale Telemetry
+
+- **OpenTelemetry integration**: optional spans for parse, compile, evaluate
+  phases, gated behind a feature flag
+- **Metric hooks**: evaluation count, duration, cache hit rate, rule count —
+  exposed as callbacks or trait implementations
+- **Evaluation replay**: record input + policy + configuration as a
+  deterministic replay bundle for reproduction
+- **Diagnostic verbosity levels**: off / errors-only / summary / detailed / trace
+
+## Review Checklist for Diagnostics
+
+When reviewing code changes, consider:
+
+1. **Error messages**: Do they include source location (file:line:col)?
+   Do they include the rule/function name? Are they actionable without
+   reading regorus source?
+2. **New error paths**: Is the error type structured? Does it carry enough
+   context for diagnosis?
+3. **Evaluation changes**: If this changes what a policy returns, can a user
+   understand why the result changed?
+4. **Resource limits**: When limits trigger, does the error help the operator
+   fix the issue (e.g., "increase instruction limit" or "simplify rule X")?
+5. **RVM changes**: Do new instructions carry source location metadata?
+6. **FFI boundary**: Are errors properly translated for each binding target?
+   Do they preserve diagnostic information across the FFI?
+7. **No secrets**: Error messages must never include policy content or input
+   data values — only paths, types, and structural information.
+
+## Architecture Notes
+
+### Zero-Cost Diagnostics Pattern
+
+Diagnostics should use Rust's zero-cost abstraction patterns:
+
+```rust
+// Feature-gated: zero cost when disabled
+#[cfg(feature = "diagnostics")]
+fn record_evaluation_step(&mut self, rule: &Rule, result: &Value) { ... }
+
+#[cfg(not(feature = "diagnostics"))]
+fn record_evaluation_step(&mut self, _rule: &Rule, _result: &Value) {}
+```
+
+Or runtime-gated with branch prediction hints:
+
+```rust
+if unlikely(self.diagnostics_enabled) {
+    self.record_step(pc, instruction);
+}
+```
+
+### Structured Diagnostic Output
+
+```json
+{
+  "evaluation_id": "uuid",
+  "policy": "rbac.rego",
+  "query": "data.rbac.allow",
+  "result": false,
+  "duration_us": 142,
+  "rules_evaluated": 7,
+  "explanation": [
+    {
+      "rule": "allow",
+      "location": "rbac.rego:15",
+      "result": "undefined",
+      "reason": "input.role not present in input"
+    }
+  ]
+}
+```
+
+### Integration Points
+
+- **Engine API**: `Engine::set_diagnostics(DiagnosticLevel)` + `Engine::take_diagnostics()`
+- **FFI**: `regorusSetDiagnostics()` / `regorusGetDiagnostics()` across all bindings
+- **CLI**: `--diagnostics=detailed` flag for `regorusctl` / evaluation tools
+- **OpenTelemetry**: Optional `tracing` crate integration behind feature flag

--- a/docs/knowledge/time-builtins-compat.md
+++ b/docs/knowledge/time-builtins-compat.md
@@ -1,0 +1,155 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Time Builtins Compatibility
+
+Deep knowledge about the time builtin functions, especially the Go
+`time.Parse` compatibility layer. Read this before modifying
+`src/builtins/time/` or any time-related builtins.
+
+## Architecture
+
+```
+src/builtins/
+  time.rs              Main time builtins
+  time/
+    compat.rs          Go time.Parse compatibility layer (largest builtin module)
+    diff.rs            Time difference calculation
+```
+
+`compat.rs` is the single most complex builtin module in the codebase.
+
+## Why Go Compatibility Matters
+
+OPA is written in Go and uses Go's `time.Parse()` function. Go's time parsing
+is fundamentally different from standard approaches:
+
+**Standard (C, Rust, Python)**: format strings with `%Y`, `%m`, `%d` etc.
+
+**Go**: uses a **reference time** as the layout. The reference time is:
+```
+Mon Jan 2 15:04:05 MST 2006
+```
+This specific date/time was chosen because each component is unique:
+- Month: January (1)
+- Day: 2
+- Hour: 15 (3 PM)
+- Minute: 04
+- Second: 05
+- Year: 2006
+- Timezone: MST
+
+OPA test cases use Go layouts, so regorus must parse and format times using
+this same convention to pass conformance tests.
+
+## The compat.rs Module
+
+This is essentially a **Rust port of Go's time parsing logic**. Key functions:
+
+### `parse(layout, value)` → Parsed time
+
+Implements Go's `time.Parse()`:
+1. Scans the layout string for known reference time components
+2. Extracts corresponding values from the input string
+3. Handles timezone parsing, AM/PM, fractional seconds
+4. Returns a Chrono `DateTime` or `NaiveDateTime`
+
+### `format(time, layout)` → Formatted string
+
+Implements Go's `time.Format()`:
+1. Scans the layout string for reference time components
+2. Substitutes actual time values
+3. Handles timezone abbreviation, offset formatting
+
+### `parse_duration(s)` → Duration
+
+Parses Go-style duration strings: `"10h12m45s"`, `"1.5h"`, `"300ms"`.
+Go's duration format is different from ISO 8601.
+
+## Tricky Aspects
+
+### Missing Components
+
+Go's `time.Parse` allows missing year or time components. Chrono is stricter.
+The compatibility layer fills in defaults:
+- Missing year → defaults to 0
+- Missing time → 00:00:00
+- Missing timezone → UTC
+
+### Timezone Parsing
+
+Go has a custom timezone parsing approach that differs from standard timezone
+databases. The compatibility layer handles:
+- Named timezones (MST, EST, PST)
+- Numeric offsets (+0700, -05:00)
+- Legacy formats
+- `parse_legacy_timezone()` for OPA-specific timezone handling
+
+### Fractional Seconds
+
+Go layouts use `.000` for milliseconds, `.000000` for microseconds,
+`.000000000` for nanoseconds. The number of zeros determines precision.
+The parser must count zeros to know the precision.
+
+### Lint Suppressions
+
+`compat.rs` suppresses several lints:
+- `clippy::arithmetic_side_effects` — ported Go code uses arithmetic directly
+- `clippy::unseparated_literal_suffix` — literal style from Go port
+- `clippy::pattern_type_mismatch`
+
+This is intentional — the module is a faithful port and the arithmetic has
+been verified in the original Go implementation.
+
+## Main Time Builtins (`time.rs`)
+
+| Function | Purpose | Complexity |
+|----------|---------|------------|
+| `time.now_ns()` | Current time in nanoseconds | Low |
+| `time.parse_rfc3339_ns()` | Parse RFC 3339 timestamp | Low |
+| `time.parse_ns()` | Parse with Go layout → nanoseconds | High (uses compat.rs) |
+| `time.parse_duration_ns()` | Parse Go duration string | Medium |
+| `time.format()` | Format with Go layout | High (uses compat.rs) |
+| `time.date()` | Extract year/month/day | Medium |
+| `time.clock()` | Extract hour/minute/second | Medium |
+| `time.weekday()` | Day of week string | Low |
+| `time.add_date()` | Date arithmetic | Medium |
+| `time.diff()` | Time difference | Medium |
+
+### Date Arithmetic
+
+`time.add_date()` uses checked arithmetic:
+- `checked_add()` and `checked_sub_months()` for year/month bounds
+- Leap year adjustments
+- Returns `Undefined` on overflow (OPA compatibility)
+
+### Nanosecond Precision
+
+All time functions work with nanosecond timestamps internally.
+`safe_timestamp_nanos()` prevents overflow when converting from seconds
+to nanoseconds.
+
+### Predefined Format Layouts
+
+`layout_with_predefined_formats()` maps OPA layout names to Chrono formats:
+- RFC 3339, RFC 822, RFC 850
+- ANSIC, Unix, Kitchen, Stamp formats
+- These must match OPA's predefined layouts exactly
+
+## OPA Conformance
+
+Time builtins are a rich source of conformance edge cases:
+
+1. **Go layout parsing** must match Go's behavior exactly
+2. **Nanosecond overflow** must return `Undefined`, not error
+3. **Timezone names** must be recognized consistently
+4. **Duration parsing** must handle Go's format (not ISO 8601)
+5. **Date arithmetic** edge cases (Feb 29, month overflow)
+
+## Dependencies
+
+- `chrono` — date/time handling (feature-gated behind `time`)
+- `chrono-tz` — timezone database (feature-gated behind `time`)
+
+Both are optional dependencies. Time builtins are not available in `no_std`
+or `opa-no-std` configurations.

--- a/docs/knowledge/tooling-architecture.md
+++ b/docs/knowledge/tooling-architecture.md
@@ -1,0 +1,223 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Tooling Architecture
+
+How regorus's current architecture supports building language servers, linters,
+analyzers, and other developer tooling. Read this when planning or implementing
+tooling features.
+
+## Foundational Infrastructure
+
+### Span Tracking
+
+Every AST node carries source location information:
+
+```rust
+pub struct Span {
+    pub source: Source,    // File reference (Rc<SourceInternal>)
+    pub line: u32,         // Line number (1-based)
+    pub col: u32,          // Column number (1-based)
+    pub start: u32,        // Byte offset in source
+    pub end: u32,          // End byte offset
+}
+```
+
+This enables precise error reporting, go-to-definition, hover information,
+and diagnostic placement. Every expression, statement, rule, and module
+carries a Span.
+
+### AST Node Types
+
+The AST (`src/ast.rs`) represents the full syntactic structure:
+
+- 25+ `Expr` variants covering all expression types
+- `LiteralStmt` for statements within rule bodies
+- `Rule` with `RuleHead` (Compr, Set, Func) and bodies
+- `Module` with package, imports, and policies
+- `Query` for ordered statement lists
+
+### Expression Indexing
+
+Each node carries indices for O(1) lookup:
+- `Expr.eidx` — unique expression index within module
+- `LiteralStmt.sidx` — statement index within query
+- `Query.qidx` — query index within module
+
+These indices enable efficient mapping between AST nodes and compilation
+artifacts (schedules, hoisted loops, binding plans).
+
+### NodeRef Pattern
+
+AST nodes use `NodeRef<T>` (wraps `Rc<T>`) with pointer-identity comparison:
+```rust
+pub struct NodeRef<T> { inner: Rc<T> }
+// PartialEq/Eq use Rc::ptr_eq (pointer identity, not value equality)
+```
+This enables cheap cloning and sharing of AST subtrees, which is important
+for tooling that needs to maintain multiple views of the AST.
+
+## Language Server Capabilities
+
+### Diagnostics (Errors and Warnings)
+
+**Already available:**
+- Parser errors with Span → precise source location for red squiggles
+- Lexer errors with line/column → tokenization failures
+- Scheduler errors → dependency cycle detection
+- Type errors from builtins → argument type mismatches
+
+**Possible additions:**
+- Unused variable detection (scheduler tracks variable definitions/uses)
+- Unreachable rule detection (via dependency analysis)
+- Shadowing warnings (scope context tracks bindings)
+- Style warnings (naming conventions, rule complexity)
+
+### Completion
+
+**What the AST provides:**
+- Package/import declarations → suggest available packages
+- Variable scope information → suggest in-scope variables
+- Builtin function registry → suggest available builtins
+- Rule paths → suggest available rules from data document
+
+**What the scheduler provides:**
+- Variable dependency analysis → which variables are defined at cursor position
+- Scope boundaries → what's visible in the current context
+
+### Go-to-Definition
+
+**What Span tracking enables:**
+- Every variable reference carries a Span
+- Every rule definition carries a Span
+- Imports link to package declarations
+- Function calls link to function definitions
+
+**Resolution path:**
+1. Find AST node at cursor position (binary search on Span ranges)
+2. Determine node type (variable, function call, import, etc.)
+3. Look up definition in scope (variables), FunctionTable (functions),
+   or module list (imports)
+4. Return definition's Span
+
+### Hover Information
+
+**What the AST provides:**
+- Expression type (from Value type system)
+- Rule documentation (doc comments if added)
+- Builtin function signatures (from BUILTINS registry)
+- Variable origin (which statement defined it)
+
+### Rename/Refactoring
+
+**What expression indexing enables:**
+- Find all references to a variable (scope analysis)
+- Find all call sites for a function (FunctionTable)
+- Find all imports of a package (import analysis)
+
+## Linter Capabilities
+
+### Static Analysis from Scheduler
+
+The scheduler's dependency analysis provides:
+- **Unused variables**: defined but never used
+- **Circular dependencies**: variable cycles within rule bodies
+- **Dead statements**: statements that can never execute (after always-failing stmt)
+
+### Static Analysis from Scope Context
+
+The compiler's scope analysis provides:
+- **Variable shadowing**: same name in nested scope
+- **Unbound variable access**: using a variable before it's defined
+- **Import shadowing**: import overriding a local definition
+
+### Static Analysis from AST
+
+Direct AST inspection can detect:
+- **Rule complexity**: number of statements, nesting depth, comprehension count
+- **Naming conventions**: package names, rule names, variable names
+- **Pattern violations**: using `=` where `:=` is preferred
+- **Deprecated syntax**: v0 patterns that should use v1 syntax
+
+### Type Analysis
+
+While Rego is dynamically typed, partial type inference is possible:
+- Literal types are known at parse time
+- Builtin return types are documented
+- Input/data schema (if provided) constrains types
+- Type conflicts in comparison operations can be detected
+
+## Analyzer Capabilities
+
+### Policy Analysis
+
+- **Entrypoint discovery**: find all rules that can be queried
+- **Data dependency mapping**: which rules depend on which data paths
+- **Input dependency mapping**: which rules depend on which input fields
+- **Cross-module analysis**: how packages interact
+
+### Performance Analysis
+
+- **Instruction count estimation**: from RVM compilation
+- **Loop complexity**: from hoisted loop analysis
+- **Comprehension nesting**: depth of nested comprehensions
+- **Virtual document chains**: how deep rule-as-data chains go
+
+### Security Analysis
+
+- **Undefined propagation paths**: where undefined values could affect decisions
+- **Missing default rules**: rules without fallback values
+- **Unbounded iteration**: loops without explicit bounds
+- **Resource limit coverage**: which evaluation paths enforce limits
+
+## Partial Evaluation (Future)
+
+Partial evaluation reduces a policy given known inputs while leaving unknown
+parts symbolic. This enables:
+
+- **Policy optimization**: pre-evaluate the known parts at compile time
+- **Policy simplification**: show users what a policy "means" for their context
+- **Incremental evaluation**: only re-evaluate changed parts
+
+### Design Considerations
+
+The current architecture supports partial evaluation through:
+- **RVM's register model**: registers could hold symbolic values
+- **Scheduler dependency analysis**: identifies independent subexpressions
+- **Value type**: could be extended with a `Symbolic` variant
+- **Compilation pipeline**: could produce residual programs with "holes"
+
+### Requirements for Implementation
+
+1. **Symbolic Value type**: extend `Value` with symbolic representation
+2. **Partial evaluation pass**: walk AST, evaluate ground subexpressions,
+   leave symbolic subexpressions
+3. **Residual program**: output a simplified policy/program
+4. **Correctness guarantee**: partial evaluation must preserve semantics
+
+## Causality Tracking (Future)
+
+Understanding why a policy produced its result:
+
+### What Exists Today
+
+- **Coverage tracking** (`coverage` feature): records which expressions
+  were evaluated during a query
+- **Tracing** (`eval_query(query, tracing=true)`): captures evaluation steps
+- **RVM frame stack**: in suspendable mode, provides execution history
+- **Active rules stack**: tracks rule evaluation chain
+
+### What's Needed
+
+1. **Decision tree**: which rules contributed to the final result
+2. **Value provenance**: where each value came from (input, data, rule)
+3. **Counterfactual analysis**: "what if this input were different?"
+4. **Human-readable explanations**: translate decision path to English
+
+### Architecture Implications
+
+- Evaluation functions need optional "trace" parameters
+- The Value type may need provenance metadata
+- The RVM could log instruction-level execution traces
+- The interpreter's context stack already tracks rule contributions
+- Memory overhead must be opt-in (not in production fast path)

--- a/docs/knowledge/value-semantics.md
+++ b/docs/knowledge/value-semantics.md
@@ -1,0 +1,148 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Value Semantics
+
+Deep knowledge about regorus's `Value` type, `Undefined` propagation, and
+three-valued logic. Read this before modifying `src/value.rs`, `src/number.rs`,
+or any evaluation code.
+
+## The Value Enum
+
+```rust
+pub enum Value {
+    Null,                              // JSON null
+    Bool(bool),                        // JSON boolean
+    Number(Number),                    // u64 | i64 | f64 | BigInt — integers get arbitrary precision; fractions use f64
+    String(Rc<str>),                   // Shared, cheap to clone
+    Array(Rc<Vec<Value>>),             // Ordered collection
+    Set(Rc<BTreeSet<Value>>),          // Ordered set (no JSON equivalent)
+    Object(Rc<BTreeMap<Value, Value>>),// Keys can be any Value, not just strings
+    Undefined,                         // Absence of value — NOT the same as Null or false
+}
+```
+
+All collection variants use `Rc` (or `Arc` with the `arc` feature). Cloning a
+Value is a refcount bump. Use `Rc::make_mut()` for copy-on-write mutation.
+
+**Implementation note:** Rego does NOT require ordered sets or objects. The
+current use of `BTreeSet` and `BTreeMap` provides deterministic ordering but
+this is an implementation detail, not a semantic requirement. The Value
+representation may change in the future (e.g., to hash-based collections for
+performance). Do not write code that depends on iteration order of Sets or
+Objects — treat them as unordered collections.
+
+## The Number Type
+
+`src/number.rs` represents numbers as one of four internal representations:
+
+| Variant | Range | Use case |
+|---------|-------|----------|
+| `UInt(u64)` | 0 to 2^64-1 | Non-negative integers |
+| `Int(i64)` | -2^63 to 2^63-1 | Negative integers |
+| `Float(f64)` | IEEE 754 | Fractional values |
+| `BigInt(Rc<BigInt>)` | Arbitrary | Overflow from u64/i64 |
+
+**Invariants:**
+- `from_bigint_owned()` normalizes: if a BigInt fits in i64/u64, it stores the
+  smaller representation.
+- Float comparison uses the `Number` type's `PartialEq` implementation, which
+  compares `f64` values directly (`#![allow(clippy::float_cmp)]` in `number.rs`).
+- `F64_SAFE_INTEGER = 2^53` — beyond this, float loses integer precision.
+- Arithmetic between variants promotes correctly (e.g., UInt + Int → Int or BigInt).
+
+**Never do raw arithmetic on Number internals.** Use the type's methods — they
+handle precision, overflow, and type promotion.
+
+## Undefined: The Critical Concept
+
+**`Undefined` is NOT `false`. `Undefined` is NOT `Null`.** Rego has three-valued
+logic where expressions can be true, false, or undefined (absent).
+
+This is the single richest source of subtle bugs in regorus.
+
+### Propagation Rules
+
+**Boolean and comparison operations** (`src/interpreter.rs:618-676`):
+```
+Undefined <op> anything  →  Undefined
+anything <op> Undefined  →  Undefined
+```
+Both operands must be defined for the operation to produce a result.
+
+**Negation** (`not`):
+```
+not true      →  false
+not false     →  true
+not Undefined →  true    ← THIS IS THE TRAP
+```
+`not Undefined` evaluates to `true` because negating "absence" means "the
+condition wasn't met" which is truthy in Rego. This is correct OPA semantics
+but extremely subtle.
+
+**Reference chains** (`a.b.c`):
+If any intermediate key is missing or Undefined, the entire chain returns
+Undefined. The interpreter navigates the path and returns Undefined at the
+first missing component.
+
+**Collection construction** (Array, Set, Object literals):
+```
+[1, Undefined, 3]  →  Undefined    (entire collection is Undefined!)
+```
+If ANY element in a collection literal is Undefined, the entire collection
+becomes Undefined. This is NOT intuitive — it doesn't skip the undefined
+element, it poisons the whole result.
+
+**Builtin function arguments**:
+```
+builtin(x, Undefined, z)  →  Undefined
+```
+If any argument to a builtin function is Undefined, the result is Undefined.
+The function is never called.
+
+**Rule bodies**:
+When a statement in a rule body evaluates to Undefined, the rule body fails
+(the rule doesn't produce a value for that input). This is Rego's core
+evaluation model — rules are "queries" that succeed or fail.
+
+### Default Rules and Undefined
+
+Default rules only fire when:
+1. No complete rule for the path produced a defined value, AND
+2. The path is Undefined in the data
+
+Precedence: `initial data > evaluated rules > default rules`
+
+### Testing Undefined
+
+Every code path that handles Values must consider:
+1. What if this Value is Undefined?
+2. What if an intermediate value in a chain is Undefined?
+3. What does `not <this expression>` mean when the expression is Undefined?
+4. Does collection construction with an Undefined element behave correctly?
+
+## Value Ordering
+
+Values implement `Ord` with a total order:
+```
+Null < Bool < Number < String < Array < Set < Object < Undefined
+```
+
+Within each variant, natural ordering applies (false < true, numeric order,
+lexicographic for strings, element-wise for collections).
+
+This ordering matters for `Set` and `Object` (which use `BTreeSet`/`BTreeMap`).
+
+## Memory Limits
+
+`Value` construction respects memory limits. The function
+`enforce_limit_anyhow()` is called during deserialization and construction to
+check the global memory limit (see `src/utils/limits/memory.rs`). This prevents
+adversarial JSON payloads from exhausting memory.
+
+## Serialization
+
+- `Set` serializes as JSON array (no JSON equivalent for sets)
+- Non-string `Object` keys are serialized by converting the key to a JSON string (via `serde_json::to_string`) and using that string as the JSON object key
+- `Undefined` serializes as the string `"<undefined>"`
+- `Number` serialization preserves precision (BigInt as string when needed)

--- a/docs/knowledge/workflow-security.md
+++ b/docs/knowledge/workflow-security.md
@@ -1,0 +1,279 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+# Knowledge: Workflow and Script Security Patterns
+
+## Overview
+
+regorus uses GitHub Actions workflows and shell scripts for CI/CD, automated
+code review, and codebase auditing. These scripts interact with untrusted
+input (PR diffs, workflow_dispatch parameters, AI model outputs) and post
+results using privileged tokens. This document catalogs the security patterns
+and anti-patterns relevant to this infrastructure.
+
+## GitHub Actions Expression Injection
+
+### The Problem
+
+GitHub Actions `${{ }}` expressions are **string-interpolated before shell
+execution**. Any user-controlled value injected this way can break out of
+string context and execute arbitrary commands.
+
+**Dangerous patterns:**
+```yaml
+# BAD — attacker-controlled input directly in shell
+run: |
+  PR_NUMBER="${{ github.event.inputs.pr_number }}"
+
+# BAD — PR title/body/branch are attacker-controlled
+run: |
+  echo "Processing: ${{ github.event.pull_request.title }}"
+```
+
+**Safe patterns:**
+```yaml
+# GOOD — pass via env, validate before use
+env:
+  PR_NUMBER: ${{ github.event.inputs.pr_number }}
+run: |
+  if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "::error::Invalid PR number"
+    exit 1
+  fi
+```
+
+### Values That Are Safe to Interpolate
+
+- `github.repository` — controlled by the org, not PR authors
+- `github.event_name` — GitHub-controlled enum
+- `github.sha`, `github.ref` — Git references (but validate format)
+- `steps.*.outputs.*` — safe **only if** the step that set them validated input
+
+### Values That Are NEVER Safe to Interpolate
+
+- `github.event.inputs.*` — user-provided workflow_dispatch inputs
+- `github.event.pull_request.title` / `.body` / `.head.ref`
+- `github.event.issue.title` / `.body`
+- `github.event.comment.body`
+- `github.event.review.body`
+- Any value derived from Git commit messages
+
+## GITHUB_OUTPUT and GITHUB_ENV Injection
+
+### The Problem
+
+Writing to `$GITHUB_OUTPUT` or `$GITHUB_ENV` using simple echo:
+
+```bash
+# VULNERABLE — newlines in VALUE inject additional outputs/env vars
+echo "key=${VALUE}" >> "$GITHUB_OUTPUT"
+```
+
+If `VALUE` contains a newline followed by `other_key=malicious`, the attacker
+controls additional workflow outputs.
+
+### Safe Pattern
+
+```bash
+# Reject newlines entirely (recommended for simple values)
+if [[ "$VALUE" == *$'\n'* ]] || [[ "$VALUE" == *$'\r'* ]]; then
+  echo "::error::Input contains newlines"
+  exit 1
+fi
+echo "key=${VALUE}" >> "$GITHUB_OUTPUT"
+
+# Or use heredoc delimiter for multiline values
+{
+  echo "key<<GHEOF"
+  echo "$VALUE"
+  echo "GHEOF"
+} >> "$GITHUB_OUTPUT"
+```
+
+## Shell Script Hardening
+
+### Required Header
+
+All regorus scripts begin with:
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+### Input Validation
+
+Validate all inputs at script entry:
+```bash
+# Repo format: owner/name
+if [[ ! "$REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+  echo "::error::Invalid repo format: '${REPO}'"
+  exit 1
+fi
+
+# Numeric values
+if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "::error::Invalid PR number: '${PR_NUMBER}'"
+  exit 1
+fi
+
+# Script names (for dispatch)
+if [[ ! "$SCRIPT" =~ ^[a-z0-9-]+$ ]]; then
+  echo "::error::Invalid script name: '${SCRIPT}'"
+  exit 1
+fi
+```
+
+### Temp File Safety
+
+```bash
+# BAD — predictable path, symlink race
+DIFF="/tmp/pr_diff.txt"
+
+# GOOD — private temp directory, auto-cleanup
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+DIFF="$TMPDIR/pr_diff.txt"
+```
+
+### Heredoc Safety
+
+```bash
+# BAD — unquoted heredoc expands variables and backticks
+cat <<PROMPT
+Review this diff: ${DIFF_CONTENT}
+PROMPT
+
+# GOOD — quoted heredoc prevents expansion
+cat <<'PROMPT'
+Review this diff: ${DIFF_CONTENT}
+PROMPT
+
+# BEST — use jq to build JSON payloads with untrusted content
+jq -n --arg diff "$DIFF_CONTENT" '{"prompt": $diff}'
+```
+
+## Model Output Sanitization
+
+### The Problem
+
+AI model responses are posted via GitHub API as review comments, issue bodies,
+or PR reviews. These responses are **untrusted** — an attacker can craft PR
+diffs that cause prompt injection, making the model output:
+
+- `@username` mentions → notification spam
+- Malicious URLs → phishing via trusted-looking automation
+- Markdown that mimics GitHub UI → social engineering
+- Excessive content → review noise
+
+### Sanitization Patterns
+
+```bash
+# Defang @mentions: insert zero-width joiner after @
+# @user → @‍user (invisible but prevents GitHub notification)
+
+# In jq (preferred — handles JSON and Unicode safely):
+jq '.title = (.title | gsub("@(?<u>[A-Za-z0-9_-])"; "@\u200d\(.u)"))
+  | .body  = (.body  | gsub("@(?<u>[A-Za-z0-9_-])"; "@\u200d\(.u)"))'
+
+# In Perl (for plain text streams):
+echo "$model_output" | perl -CSD -pe 's/\@([A-Za-z0-9_-])/\@\x{200d}$1/g'
+
+# Note: sed does not reliably support Unicode codepoint escapes; prefer jq or Perl.
+```
+
+### Silent Failure Detection
+
+```bash
+# Track failures across perspectives/analyses
+FAILED=0
+TOTAL=0
+
+for item in $ITEMS; do
+  TOTAL=$((TOTAL + 1))
+  result=$(call_model ...) || { FAILED=$((FAILED + 1)); continue; }
+done
+
+# Fail if ALL analyses failed (model/API issue, not "no findings")
+if [ "$TOTAL" -gt 0 ] && [ "$FAILED" -eq "$TOTAL" ]; then
+  echo "::error::All $TOTAL analyses failed"
+  exit 1
+fi
+```
+
+## SIGPIPE Handling
+
+### The Problem
+
+Under `set -eo pipefail`, piping to `head` causes SIGPIPE (exit 141) when
+the upstream command produces more output than `head` consumes:
+
+```bash
+# BAD — SIGPIPE if diff > 60000 bytes
+gh api ... | head -c 60000
+```
+
+### Safe Pattern
+
+```bash
+# GOOD — fetch to file first, then truncate
+gh api ... > "$TMPDIR/full_output.txt"
+head -c 60000 "$TMPDIR/full_output.txt" > "$TMPDIR/truncated.txt"
+```
+
+## Workflow Permission Model
+
+### Principle of Least Privilege
+
+```yaml
+permissions:
+  contents: read        # Only if checking out code
+  pull-requests: write  # Only if posting review comments
+  issues: write         # Only if creating/updating issues
+  models: read          # Only if calling GitHub Models API
+```
+
+### Token Scoping
+
+- `GITHUB_TOKEN` permissions are set per-workflow, not per-step
+- Use the `copilot` environment for secrets that should only be available
+  to Copilot-related workflows
+- Never pass tokens to model API calls beyond what's needed for authentication
+
+## regorus-Specific Patterns
+
+### Action Pinning Convention
+
+All `actions/*` references use full SHA pins, managed by Dependabot:
+```yaml
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+```
+
+### Script Dispatch Safety
+
+The codebase-audit workflow allows preset configs to specify a script name.
+This must be validated:
+```bash
+# Script name must be [a-z0-9-]+ — no path separators, no dots
+if [[ ! "$SCRIPT" =~ ^[a-z0-9-]+$ ]]; then
+  echo "::error::Invalid script name"
+  exit 1
+fi
+# Script must exist in the expected directory
+if [ ! -f ".github/scripts/${SCRIPT}.sh" ]; then
+  echo "::error::Script not found: ${SCRIPT}"
+  exit 1
+fi
+```
+
+## Checklist for New Workflows/Scripts
+
+1. ☐ No `${{ }}` expressions in `run:` blocks (use `env:`)
+2. ☐ All inputs validated at entry (format, length, no control chars)
+3. ☐ Temp files use `mktemp` + `trap` cleanup
+4. ☐ Heredocs are quoted when containing external data
+5. ☐ Model output sanitized before posting (defang @mentions, URLs)
+6. ☐ Silent failures detected and reported
+7. ☐ Permissions minimally scoped
+8. ☐ Actions pinned by SHA
+9. ☐ SIGPIPE handled (no `| head` on unbounded streams)
+10. ☐ `set -euo pipefail` at script entry

--- a/examples/regorus/main.rs
+++ b/examples/regorus/main.rs
@@ -46,6 +46,7 @@ fn rego_eval(
     non_strict: bool,
     #[cfg(feature = "coverage")] coverage: bool,
     v0: bool,
+    format: &str,
 ) -> Result<()> {
     // Create engine.
     let mut engine = regorus::Engine::new();
@@ -117,8 +118,17 @@ fn rego_eval(
     // to use.
     let results = engine.eval_query(query, enable_tracing)?;
 
-    println!("{}", serde_json::to_string_pretty(&results)?);
-
+    match format {
+        "sarif" => {
+            let config = regorus::sarif::SarifConfig::default();
+            let report = regorus::sarif::SarifReport::from_query_results(&results, &config)
+                .map_err(|e| anyhow!("SARIF generation failed: {e}"))?;
+            println!("{}", report.to_json().map_err(|e| anyhow!("{e}"))?);
+        }
+        "json" | _ => {
+            println!("{}", serde_json::to_string_pretty(&results)?);
+        }
+    }
     #[cfg(feature = "coverage")]
     if coverage {
         let report = engine.get_coverage_report()?;
@@ -249,9 +259,11 @@ enum RegorusCommand {
         /// Turn on Rego language v0.
         #[arg(long)]
         v0: bool,
-    },
 
-    /// Tokenize a Rego policy.
+        /// Output format (json or sarif).
+        #[arg(long, short = 'F', default_value = "json")]
+        format: String,
+    },    /// Tokenize a Rego policy.
     Lex {
         /// Rego policy file.
         file: String,
@@ -331,6 +343,7 @@ fn main() -> Result<()> {
             #[cfg(feature = "coverage")]
             coverage,
             v0,
+            format,
         } => rego_eval(
             &bundles,
             &data,
@@ -341,6 +354,7 @@ fn main() -> Result<()> {
             #[cfg(feature = "coverage")]
             coverage,
             v0,
+            &format,
         ),
         RegorusCommand::Lex { file, verbose } => rego_lex(file, verbose),
         RegorusCommand::Parse { file, v0 } => rego_parse(file, v0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ mod schema;
 pub mod target;
 #[cfg(any(test, all(feature = "yaml", feature = "std")))]
 pub mod test_utils;
+pub mod sarif;
 pub mod utils;
 mod value;
 

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -1,0 +1,435 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! SARIF (Static Analysis Results Interchange Format) output for policy evaluation.
+//!
+//! This module converts policy evaluation results into SARIF v2.1.0 format,
+//! enabling integration with GitHub Advanced Security, Azure DevOps, and other
+//! SARIF-consuming tools.
+//!
+//! # Usage
+//! ```no_run
+//! use regorus::sarif::{SarifReport, SarifConfig};
+//! use regorus::Engine;
+//!
+//! let mut engine = Engine::new();
+//! // ... load policies and data ...
+//! let results = engine.eval_query("data.policy.violations".to_string(), false)?;
+//! let report = SarifReport::from_query_results(&results, &SarifConfig::default())?;
+//! println!("{}", report.to_json()?);
+//! ```
+
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use serde::Serialize;
+
+use crate::QueryResults;
+use crate::Value;
+
+/// Configuration for SARIF report generation.
+#[derive(Clone, Debug)]
+pub struct SarifConfig {
+    /// Tool name reported in the SARIF output.
+    pub tool_name: String,
+    /// Tool version.
+    pub tool_version: String,
+    /// Base URI for artifact locations (e.g., file:///workspace/).
+    pub base_uri: String,
+    /// Severity mapping: field name in violation objects that maps to SARIF level.
+    pub severity_field: String,
+    /// Message field name in violation objects.
+    pub message_field: String,
+    /// File/location field name in violation objects.
+    pub location_field: String,
+    /// Rule ID field name in violation objects.
+    pub rule_id_field: String,
+    /// Maximum number of results to include (0 = unlimited).
+    pub max_results: usize,
+}
+
+impl Default for SarifConfig {
+    fn default() -> Self {
+        Self {
+            tool_name: "regorus".to_string(),
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            base_uri: String::new(),
+            severity_field: "severity".to_string(),
+            message_field: "msg".to_string(),
+            location_field: "file".to_string(),
+            rule_id_field: "rule_id".to_string(),
+            max_results: 0,
+        }
+    }
+}
+
+/// A complete SARIF v2.1.0 report.
+#[derive(Debug, Serialize)]
+pub struct SarifReport {
+    #[serde(rename = "$schema")]
+    schema: String,
+    version: String,
+    runs: Vec<SarifRun>,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifRun {
+    tool: SarifTool,
+    results: Vec<SarifResult>,
+    #[serde(rename = "originalUriBaseIds")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    original_uri_base_ids: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifTool {
+    driver: SarifToolComponent,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifToolComponent {
+    name: String,
+    version: String,
+    #[serde(rename = "informationUri")]
+    information_uri: String,
+    rules: Vec<SarifReportingDescriptor>,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifReportingDescriptor {
+    id: String,
+    #[serde(rename = "shortDescription")]
+    short_description: SarifMessage,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifResult {
+    #[serde(rename = "ruleId")]
+    rule_id: String,
+    level: String,
+    message: SarifMessage,
+    locations: Vec<SarifLocation>,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifLocation {
+    #[serde(rename = "physicalLocation")]
+    physical_location: SarifPhysicalLocation,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifPhysicalLocation {
+    #[serde(rename = "artifactLocation")]
+    artifact_location: SarifArtifactLocation,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifArtifactLocation {
+    uri: String,
+    #[serde(rename = "uriBaseId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uri_base_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct SarifMessage {
+    text: String,
+}
+
+/// Maps OPA-style severity strings to SARIF levels.
+fn map_severity(severity: &str) -> &'static str {
+    match severity.to_lowercase().as_str() {
+        "error" | "critical" | "high" => "error",
+        "warning" | "medium" => "warning",
+        "info" | "note" | "low" => "note",
+        _ => "warning",
+    }
+}
+
+/// Sanitize a string for use as a SARIF rule ID.
+/// Rule IDs must be stable identifiers — only alphanumeric, dash, dot, slash allowed.
+fn sanitize_rule_id(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '.' || c == '/' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Construct an artifact URI from the location field value.
+/// If base_uri is configured, the location is treated as relative.
+fn build_artifact_uri(location: &str, base_uri: &str) -> (String, Option<String>) {
+    if base_uri.is_empty() {
+        // Use location as-is; if it looks like an absolute path, convert to file URI
+        if location.starts_with('/') {
+            (format!("file://{location}"), None)
+        } else {
+            (location.to_string(), None)
+        }
+    } else {
+        // Strip leading slash/dot from relative path
+        let relative = location.trim_start_matches('/').trim_start_matches("./");
+        (relative.to_string(), Some("SRCROOT".to_string()))
+    }
+}
+
+impl SarifReport {
+    /// Create a SARIF report from query results.
+    ///
+    /// Expects query results where each result expression value is either:
+    /// - A set/array of violation objects, or
+    /// - A single violation object
+    ///
+    /// Violation objects should have fields matching the config (msg, severity, file, rule_id).
+    pub fn from_query_results(
+        query_results: &QueryResults,
+        config: &SarifConfig,
+    ) -> Result<Self, String> {
+        let mut results = Vec::new();
+        let mut rules_seen = Vec::new();
+
+        for query_result in query_results.result.iter() {
+            for expression in query_result.expressions.iter() {
+                let violations = extract_violations(&expression.value);
+                for violation in violations {
+                    if config.max_results > 0 && results.len() >= config.max_results {
+                        break;
+                    }
+
+                    let rule_id = extract_string_field(&violation, &config.rule_id_field)
+                        .unwrap_or_else(|| "policy-violation".to_string());
+                    let rule_id = sanitize_rule_id(&rule_id);
+
+                    let message = extract_string_field(&violation, &config.message_field)
+                        .unwrap_or_else(|| "Policy violation detected".to_string());
+
+                    let severity = extract_string_field(&violation, &config.severity_field)
+                        .unwrap_or_else(|| "warning".to_string());
+
+                    let location = extract_string_field(&violation, &config.location_field)
+                        .unwrap_or_else(|| "unknown".to_string());
+
+                    let level = map_severity(&severity).to_string();
+                    let (uri, uri_base_id) = build_artifact_uri(&location, &config.base_uri);
+
+                    // Track unique rules
+                    if !rules_seen.iter().any(|r: &String| *r == rule_id) {
+                        rules_seen.push(rule_id.clone());
+                    }
+
+                    results.push(SarifResult {
+                        rule_id: rule_id.clone(),
+                        level,
+                        message: SarifMessage { text: message },
+                        locations: vec![SarifLocation {
+                            physical_location: SarifPhysicalLocation {
+                                artifact_location: SarifArtifactLocation { uri, uri_base_id },
+                            },
+                        }],
+                    });
+                }
+            }
+        }
+
+        let rules: Vec<SarifReportingDescriptor> = rules_seen
+            .iter()
+            .map(|id| SarifReportingDescriptor {
+                id: id.clone(),
+                short_description: SarifMessage {
+                    text: format!("Policy rule: {id}"),
+                },
+            })
+            .collect();
+
+        let original_uri_base_ids = if !config.base_uri.is_empty() {
+            Some(serde_json::json!({
+                "SRCROOT": {
+                    "uri": config.base_uri
+                }
+            }))
+        } else {
+            None
+        };
+
+        Ok(SarifReport {
+            schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json".to_string(),
+            version: "2.1.0".to_string(),
+            runs: vec![SarifRun {
+                tool: SarifTool {
+                    driver: SarifToolComponent {
+                        name: config.tool_name.clone(),
+                        version: config.tool_version.clone(),
+                        information_uri: "https://github.com/microsoft/regorus".to_string(),
+                        rules,
+                    },
+                },
+                results,
+                original_uri_base_ids,
+            }],
+        })
+    }
+
+    /// Serialize the SARIF report to a JSON string.
+    pub fn to_json(&self) -> Result<String, String> {
+        serde_json::to_string_pretty(self).map_err(|e| format!("JSON serialization failed: {e}"))
+    }
+
+    /// Returns the total number of results in the report.
+    pub fn result_count(&self) -> usize {
+        self.runs.iter().map(|r| r.results.len()).sum()
+    }
+}
+
+/// Extract violation objects from a Value.
+/// Handles sets, arrays, and single objects.
+fn extract_violations(value: &Value) -> Vec<&Value> {
+    match value {
+        Value::Array(arr) => arr.iter().collect(),
+        Value::Set(set) => set.iter().collect(),
+        Value::Object(_) => vec![value],
+        _ => vec![],
+    }
+}
+
+/// Extract a string field from a Value object.
+fn extract_string_field(value: &Value, field: &str) -> Option<String> {
+    if let Value::Object(obj) = value {
+        for (k, v) in obj.iter() {
+            if let Value::String(key_str) = k {
+                if key_str.as_ref() == field {
+                    return match v {
+                        Value::String(s) => Some(s.as_ref().to_string()),
+                        other => Some(format!("{other}")),
+                    };
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Engine, Value};
+
+    #[test]
+    fn test_empty_results() {
+        let engine = Engine::new();
+        let results = crate::QueryResults {
+            result: vec![],
+        };
+        let report = SarifReport::from_query_results(&results, &SarifConfig::default()).unwrap();
+        assert_eq!(report.result_count(), 0);
+        let json = report.to_json().unwrap();
+        assert!(json.contains("\"version\": \"2.1.0\""));
+    }
+
+    #[test]
+    fn test_severity_mapping() {
+        assert_eq!(map_severity("error"), "error");
+        assert_eq!(map_severity("critical"), "error");
+        assert_eq!(map_severity("HIGH"), "error");
+        assert_eq!(map_severity("warning"), "warning");
+        assert_eq!(map_severity("medium"), "warning");
+        assert_eq!(map_severity("info"), "note");
+        assert_eq!(map_severity("low"), "note");
+        assert_eq!(map_severity("unknown"), "warning");
+    }
+
+    #[test]
+    fn test_sanitize_rule_id() {
+        assert_eq!(sanitize_rule_id("my-rule.v1"), "my-rule.v1");
+        assert_eq!(sanitize_rule_id("rule with spaces"), "rule_with_spaces");
+        assert_eq!(sanitize_rule_id("data.policy/deny"), "data.policy/deny");
+    }
+
+    #[test]
+    fn test_build_artifact_uri_absolute() {
+        let (uri, base) = build_artifact_uri("/home/user/file.rego", "");
+        assert_eq!(uri, "file:///home/user/file.rego");
+        assert!(base.is_none());
+    }
+
+    #[test]
+    fn test_build_artifact_uri_relative() {
+        let (uri, base) = build_artifact_uri("./src/policy.rego", "file:///workspace/");
+        assert_eq!(uri, "src/policy.rego");
+        assert_eq!(base.unwrap(), "SRCROOT");
+    }
+
+    #[test]
+    fn test_max_results_limit() {
+        let mut engine = Engine::new();
+        engine
+            .add_policy(
+                "test.rego".to_string(),
+                r#"
+                package test
+                violations contains v if {
+                    some i in [1, 2, 3, 4, 5]
+                    v := {"msg": sprintf("violation %d", [i]), "severity": "error", "file": "test.rego", "rule_id": "test-rule"}
+                }
+                "#
+                .to_string(),
+            )
+            .unwrap();
+
+        let results = engine
+            .eval_query("data.test.violations".to_string(), false)
+            .unwrap();
+
+        let mut config = SarifConfig::default();
+        config.max_results = 3;
+
+        let report = SarifReport::from_query_results(&results, &config).unwrap();
+        assert_eq!(report.result_count(), 3);
+    }
+
+    #[test]
+    fn test_full_sarif_structure() {
+        let mut engine = Engine::new();
+        engine
+            .add_policy(
+                "policy.rego".to_string(),
+                r#"
+                package security
+                deny contains msg if {
+                    msg := {
+                        "msg": "Container running as root",
+                        "severity": "critical",
+                        "file": "deployment.yaml",
+                        "rule_id": "container-security/no-root"
+                    }
+                }
+                "#
+                .to_string(),
+            )
+            .unwrap();
+
+        let results = engine
+            .eval_query("data.security.deny".to_string(), false)
+            .unwrap();
+
+        let config = SarifConfig {
+            base_uri: "file:///workspace/".to_string(),
+            ..Default::default()
+        };
+
+        let report = SarifReport::from_query_results(&results, &config).unwrap();
+        assert_eq!(report.result_count(), 1);
+
+        let json = report.to_json().unwrap();
+        assert!(json.contains("container-security/no-root"));
+        assert!(json.contains("Container running as root"));
+        assert!(json.contains("\"level\": \"error\""));
+        assert!(json.contains("deployment.yaml"));
+        assert!(json.contains("SRCROOT"));
+    }
+}


### PR DESCRIPTION
## Summary

Add SARIF (Static Analysis Results Interchange Format) v2.1.0 output support to regorus, enabling integration with GitHub Advanced Security code scanning, Azure DevOps, and other SARIF-consuming tools.

## Changes

- **New module `src/sarif.rs`**: Core SARIF report generation with configurable field mapping
- **CLI enhancement**: `--format sarif` option on the `eval` command  
- **Configurable**: Field names for message, severity, file, and rule_id can be customized
- **Max results limit**: Prevent unbounded output for large violation sets

## Usage

```bash
# Evaluate policy and output violations in SARIF format
regorus eval -b policies/ -d data.json -i input.json \
  --format sarif 'data.security.deny'

# Pipe to GitHub code scanning
regorus eval ... --format sarif 'data.policy.violations' > results.sarif
gh api repos/{owner}/{repo}/code-scanning/sarifs -f sarif=@results.sarif
```

## Design Decisions

- Violation objects are expected to have `msg`, `severity`, `file`, and `rule_id` fields (configurable)
- OPA-style severity strings are mapped to SARIF levels: error/critical/high → error, warning/medium → warning, info/note/low → note
- Absolute paths are converted to `file://` URIs; relative paths use `SRCROOT` base URI
- The module is always compiled (no feature gate) since it adds minimal binary size

## Testing

7 unit tests covering:
- Empty results
- Severity mapping
- Rule ID sanitization  
- URI construction (absolute + relative)
- Max results enforcement
- Full SARIF structure validation