### PR TITLE
refactor(value): migrate Value::Set to Set storage abstraction

### DIFF
--- a/src/builtins/graph.rs
+++ b/src/builtins/graph.rs
@@ -128,7 +128,7 @@ fn visit(
                 arr.len()
             }
             Some(Value::Set(set)) => {
-                for n in set.iter().rev() {
+                for n in set.iter_sorted().rev() {
                     visit(graph, visited, n, path, paths)?;
                 }
                 set.len()

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -7,10 +7,8 @@ use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_set};
 use crate::lexer::Span;
-use crate::value::Value;
+use crate::value::{Set, Value};
 use crate::*;
-
-use alloc::collections::BTreeSet;
 
 use anyhow::{bail, Result};
 
@@ -24,19 +22,19 @@ pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn
 pub fn intersection(expr1: &Expr, expr2: &Expr, v1: Value, v2: Value) -> Result<Value> {
     let s1 = ensure_set("intersection", expr1, v1)?;
     let s2 = ensure_set("intersection", expr2, v2)?;
-    Ok(Value::from_set(s1.intersection(&s2).cloned().collect()))
+    Ok(s1.intersection(&s2).into_value())
 }
 
 pub fn union(expr1: &Expr, expr2: &Expr, v1: Value, v2: Value) -> Result<Value> {
     let s1 = ensure_set("union", expr1, v1)?;
     let s2 = ensure_set("union", expr2, v2)?;
-    Ok(Value::from_set(s1.union(&s2).cloned().collect()))
+    Ok(s1.union(&s2).into_value())
 }
 
 pub fn difference(expr1: &Expr, expr2: &Expr, v1: Value, v2: Value) -> Result<Value> {
     let s1 = ensure_set("difference", expr1, v1)?;
     let s2 = ensure_set("difference", expr2, v2)?;
-    Ok(Value::from_set(s1.difference(&s2).cloned().collect()))
+    Ok(s1.difference(&s2).into_value())
 }
 
 fn binary_set_union(
@@ -49,7 +47,7 @@ fn binary_set_union(
     ensure_args_count(span, name, params, args, 2)?;
     let left = ensure_set(name, &params[0], args[0].clone())?;
     let right = ensure_set(name, &params[1], args[1].clone())?;
-    Ok(Value::from_set(left.union(&right).cloned().collect()))
+    Ok(left.union(&right).into_value())
 }
 
 fn binary_set_intersection(
@@ -62,9 +60,7 @@ fn binary_set_intersection(
     ensure_args_count(span, name, params, args, 2)?;
     let left = ensure_set(name, &params[0], args[0].clone())?;
     let right = ensure_set(name, &params[1], args[1].clone())?;
-    Ok(Value::from_set(
-        left.intersection(&right).cloned().collect(),
-    ))
+    Ok(left.intersection(&right).into_value())
 }
 
 fn intersection_of_set_of_sets(
@@ -77,7 +73,7 @@ fn intersection_of_set_of_sets(
     ensure_args_count(span, name, params, args, 1)?;
     let set = ensure_set(name, &params[0], args[0].clone())?;
 
-    let mut res = BTreeSet::new();
+    let mut res = Set::new();
     let mut first = true;
 
     for s in set.iter() {
@@ -92,11 +88,11 @@ fn intersection_of_set_of_sets(
             res.clone_from(s);
             first = false;
         } else {
-            res = res.intersection(s).cloned().collect();
+            res = res.intersection(s);
         }
     }
 
-    Ok(Value::from_set(res))
+    Ok(res.into_value())
 }
 
 fn union_of_set_of_sets(
@@ -109,7 +105,7 @@ fn union_of_set_of_sets(
     ensure_args_count(span, name, params, args, 1)?;
     let set = ensure_set(name, &params[0], args[0].clone())?;
 
-    let mut res = BTreeSet::new();
+    let mut res = Set::new();
 
     for s in set.iter() {
         let s = match s {
@@ -119,8 +115,8 @@ fn union_of_set_of_sets(
             ),
         };
 
-        res = res.union(s).cloned().collect();
+        res = res.union(s);
     }
 
-    Ok(Value::from_set(res))
+    Ok(res.into_value())
 }

--- a/src/builtins/utils.rs
+++ b/src/builtins/utils.rs
@@ -5,12 +5,9 @@
 use crate::ast::{Expr, Ref};
 use crate::lexer::Span;
 use crate::number::Number;
-use crate::value::Object;
+use crate::value::{Object, Set};
 use crate::Rc;
-use crate::Value;
 use crate::*;
-
-use alloc::collections::BTreeSet;
 
 use anyhow::{bail, Result};
 
@@ -159,7 +156,7 @@ pub fn ensure_array(fcn: &str, arg: &Expr, v: Value) -> Result<Rc<Vec<Value>>> {
     })
 }
 
-pub fn ensure_set(fcn: &str, arg: &Expr, v: Value) -> Result<Rc<BTreeSet<Value>>> {
+pub fn ensure_set(fcn: &str, arg: &Expr, v: Value) -> Result<Rc<Set>> {
     Ok(match v {
         Value::Set(s) => s,
         _ => {

--- a/src/languages/azure_policy/compiler/metadata.rs
+++ b/src/languages/azure_policy/compiler/metadata.rs
@@ -17,7 +17,7 @@ use crate::languages::azure_policy::ast::{
     Condition, EffectKind, FieldKind, JsonValue, Lhs, OperatorKind, PolicyDefinition, PolicyRule,
     ValueOrExpr,
 };
-use crate::{Rc, Value};
+use crate::Value;
 
 use super::core::Compiler;
 
@@ -237,7 +237,7 @@ impl Compiler {
                 .iter()
                 .map(|p| Value::String(p.name.as_str().into()))
                 .collect();
-            annot.insert("parameter_names".to_string(), Value::Set(Rc::new(set)));
+            annot.insert("parameter_names".to_string(), Value::from(set));
         }
 
         // Extra fields: policyType → policy_type, id → policy_id, name → policy_name.
@@ -279,6 +279,6 @@ fn insert_string_set_annotation(
             .iter()
             .map(|s| Value::String(s.as_str().into()))
             .collect();
-        annot.insert(key.to_string(), Value::Set(Rc::new(set)));
+        annot.insert(key.to_string(), Value::from(set));
     }
 }

--- a/src/languages/azure_rbac/builtins/functions.rs
+++ b/src/languages/azure_rbac/builtins/functions.rs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use alloc::collections::BTreeSet;
 use alloc::string::ToString as _;
 use alloc::vec;
 
-use crate::value::Value;
+use crate::value::{Set, Value};
 
 use super::actions;
 use super::common;
@@ -42,12 +41,12 @@ pub(super) fn normalize_set(value: &Value) -> Result<Value, RbacBuiltinError> {
         Value::Set(_) => Ok(value.clone()),
         Value::Array(ref list) => {
             // Convert arrays to sets by de-duplicating elements.
-            let set: BTreeSet<Value> = list.iter().cloned().collect();
+            let set: Set = list.iter().cloned().collect();
             Ok(Value::from(set))
         }
         _ => {
             // Non-collections become singleton sets.
-            let mut set = BTreeSet::new();
+            let mut set = Set::new();
             set.insert(value.clone());
             Ok(Value::from(set))
         }

--- a/src/languages/azure_rbac/builtins/lists.rs
+++ b/src/languages/azure_rbac/builtins/lists.rs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use alloc::collections::BTreeSet;
-
-use crate::value::Value;
+use crate::value::{Set, Value};
 
 use super::evaluator::RbacBuiltinError;
 
@@ -28,7 +26,7 @@ fn list_contains_values(list: &[Value], needle: &Value) -> bool {
 }
 
 // For sets, treat a list/set needle as "all elements are contained".
-fn set_contains_values(set: &BTreeSet<Value>, needle: &Value) -> bool {
+fn set_contains_values(set: &Set, needle: &Value) -> bool {
     match *needle {
         // For collection needles, require all elements to be present.
         Value::Array(ref right_list) => right_list.iter().all(|item| set.contains(item)),

--- a/src/languages/rego/compiler/expressions/collection_literals.rs
+++ b/src/languages/rego/compiler/expressions/collection_literals.rs
@@ -11,9 +11,8 @@ use crate::ast::{Expr, ExprRef};
 use crate::lexer::Span;
 use crate::rvm::instructions::{ArrayCreateParams, ObjectCreateParams, SetCreateParams};
 use crate::rvm::Instruction;
-use crate::value::Object;
+use crate::value::{Object, Set};
 use crate::{Rc, Value};
-use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 
 /// Try to evaluate an expression as a compile-time constant.
@@ -39,8 +38,8 @@ pub(in crate::languages::rego::compiler) fn try_eval_const(expr: &Expr) -> Optio
         Expr::Set { items, .. } => items
             .iter()
             .map(|i| try_eval_const(i.as_ref()))
-            .collect::<Option<BTreeSet<_>>>()
-            .map(|s| Value::Set(Rc::new(s))),
+            .collect::<Option<Set>>()
+            .map(Value::from),
         Expr::Object { fields, .. } => fields
             .iter()
             .map(|(_, k, v)| Some((try_eval_const(k.as_ref())?, try_eval_const(v.as_ref())?)))
@@ -88,11 +87,10 @@ impl<'a> Compiler<'a> {
         items: &[ExprRef],
         span: &Span,
     ) -> Result<Register> {
-        let all_const: Option<BTreeSet<_>> =
-            items.iter().map(|i| try_eval_const(i.as_ref())).collect();
+        let all_const: Option<Set> = items.iter().map(|i| try_eval_const(i.as_ref())).collect();
         if let Some(values) = all_const {
             let dest = self.alloc_register();
-            let literal_idx = self.add_literal(Value::Set(Rc::new(values)));
+            let literal_idx = self.add_literal(Value::from(values));
             self.emit_instruction(Instruction::Load { dest, literal_idx }, span);
             return Ok(dest);
         }

--- a/src/rvm/program/metadata.rs
+++ b/src/rvm/program/metadata.rs
@@ -194,15 +194,15 @@ impl MetadataValue {
 
     /// Convert this `MetadataValue` into a regorus `Value`.
     pub fn to_value(&self) -> crate::value::Value {
-        use crate::value::Value;
+        use crate::value::{Set, Value};
         match *self {
             MetadataValue::String(ref s) => Value::String(s.as_str().into()),
             MetadataValue::StringSet(ref set) => {
-                let mut bset = BTreeSet::new();
+                let mut bset = Set::new();
                 for s in set {
                     bset.insert(Value::String(s.as_str().into()));
                 }
-                Value::Set(Rc::new(bset))
+                Value::from(bset)
             }
             MetadataValue::Bool(b) => Value::Bool(b),
             MetadataValue::Integer(n) => Value::from(n),
@@ -301,7 +301,7 @@ mod tests {
         let mut set = BTreeSet::new();
         set.insert(Value::String("a".into()));
         set.insert(Value::String("b".into()));
-        let v = Value::Set(Rc::new(set));
+        let v = Value::from(set);
         assert_round_trip(&v, &v);
     }
 
@@ -328,7 +328,7 @@ mod tests {
         let mut set = BTreeSet::new();
         set.insert(Value::String("a".into()));
         set.insert(Value::from(1_i64));
-        let v = Value::Set(Rc::new(set));
+        let v = Value::from(set);
         let mv = MetadataValue::from_value(&v);
         assert!(
             matches!(mv, MetadataValue::List(_)),

--- a/src/rvm/program/serialization/value.rs
+++ b/src/rvm/program/serialization/value.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-use alloc::collections::BTreeSet;
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -11,8 +10,7 @@ use serde::ser::{SerializeSeq as _, SerializeTuple as _};
 use serde::{Deserialize, Serialize};
 
 use crate::number::Number;
-use crate::value::Object;
-use crate::value::Value;
+use crate::value::{Object, Set, Value};
 
 const VARIANT_NULL: u32 = 0;
 const VARIANT_BOOL: u32 = 1;
@@ -118,7 +116,7 @@ impl<'a> Serialize for BinaryValueSlice<'a> {
     }
 }
 
-struct BinarySetRef<'a>(&'a BTreeSet<Value>);
+struct BinarySetRef<'a>(&'a Set);
 
 impl<'a> Serialize for BinarySetRef<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -126,7 +124,7 @@ impl<'a> Serialize for BinarySetRef<'a> {
         S: serde::Serializer,
     {
         let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for value in self.0.iter() {
+        for value in self.0.iter_sorted() {
             seq.serialize_element(&BinaryValueRef(value))?;
         }
         seq.end()
@@ -254,7 +252,7 @@ impl<'de> Visitor<'de> for BinaryValueVisitor {
             }
             (BinaryVariant::Set, variant) => {
                 let items: Vec<BinaryValue> = variant.newtype_variant()?;
-                let mut set = BTreeSet::new();
+                let mut set = Set::new();
                 for item in items {
                     set.insert(item.into_value());
                 }

--- a/src/rvm/vm/arithmetic.rs
+++ b/src/rvm/vm/arithmetic.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::pattern_type_mismatch, clippy::needless_borrowed_reference)]
 
 use crate::number::Number;
-use crate::value::Value;
+use crate::value::{Set, Value};
 
 use super::errors::{Result, VmError};
 use super::machine::RegoVM;
@@ -30,8 +30,7 @@ impl RegoVM {
         match (a, b) {
             (&Value::Number(ref x), &Value::Number(ref y)) => Ok(Value::from(x.sub(y)?)),
             (&Value::Set(ref left), &Value::Set(ref right)) => {
-                let diff: alloc::collections::BTreeSet<Value> =
-                    left.difference(right).cloned().collect();
+                let diff: Set = left.difference(right);
                 Ok(Value::from(diff))
             }
             _ => Err(VmError::InvalidSubtraction {

--- a/src/rvm/vm/comprehension.rs
+++ b/src/rvm/vm/comprehension.rs
@@ -62,11 +62,8 @@ impl RegoVM {
                     if set.is_empty() {
                         None
                     } else {
-                        Some(IterationState::Set {
-                            items: set,
-                            current_item: None,
-                            first_iteration: true,
-                        })
+                        let cursor = set.cursor();
+                        Some(IterationState::Set { set, cursor })
                     }
                 }
                 Value::Undefined => None,
@@ -148,11 +145,8 @@ impl RegoVM {
                     if set.is_empty() {
                         None
                     } else {
-                        Some(IterationState::Set {
-                            items: set,
-                            current_item: None,
-                            first_iteration: true,
-                        })
+                        let cursor = set.cursor();
+                        Some(IterationState::Set { set, cursor })
                     }
                 }
                 Value::Undefined => None,
@@ -250,21 +244,6 @@ impl RegoVM {
         };
 
         let result_reg = comprehension_context.result_reg;
-        // Snapshot the iteration value register BEFORE taking the result
-        // register: if the comprehension compiler ever allocates
-        // `result_reg == context.value_reg`, the writeback at the bottom
-        // of this function would clobber the value register, and a
-        // post-writeback read here would feed the wrong value into
-        // `IterationState::Set::current_item`. Only Set needs the snapshot
-        // (Object uses a self-advancing cursor; Array advances by index).
-        let set_resume_snapshot = if matches!(
-            comprehension_context.iteration_state,
-            Some(IterationState::Set { .. })
-        ) {
-            Some(self.get_register(comprehension_context.value_reg)?.clone())
-        } else {
-            None
-        };
         // Take ownership of the result register so Rc refcount stays at 1,
         // allowing Rc::make_mut to mutate in-place instead of deep-cloning.
         let mut current_result = self.take_register(result_reg)?;
@@ -302,16 +281,6 @@ impl RegoVM {
         self.set_register(result_reg, current_result)?;
 
         if let Some(iter_state) = comprehension_context.iteration_state.as_mut() {
-            // Set's `Bound::Excluded(current_item)` resume scheme needs the
-            // pre-mutation snapshot taken at the top of this function.
-            // Object uses a self-advancing cursor and needs no snapshot.
-            if let IterationState::Set {
-                ref mut current_item,
-                ..
-            } = *iter_state
-            {
-                *current_item = set_resume_snapshot;
-            }
             iter_state.advance();
             let has_next = self.setup_next_iteration(
                 iter_state,
@@ -349,15 +318,7 @@ impl RegoVM {
                 pc: self.pc,
             })?;
 
-        let (
-            value_to_add,
-            key_value,
-            mode,
-            result_reg_idx,
-            key_reg_idx,
-            value_reg_idx,
-            iter_is_set,
-        ) = {
+        let (value_to_add, key_value, mode, result_reg_idx, key_reg_idx, value_reg_idx) = {
             let frame =
                 self.execution_stack
                     .get(comprehension_index)
@@ -378,9 +339,6 @@ impl RegoVM {
 
                 let result_reg_idx = context.result_reg;
                 let mode = context.mode.clone();
-                let iter_is_set =
-                    matches!(context.iteration_state, Some(IterationState::Set { .. }));
-
                 (
                     value_to_add,
                     key_value,
@@ -388,7 +346,6 @@ impl RegoVM {
                     result_reg_idx,
                     context.key_reg,
                     context.value_reg,
-                    iter_is_set,
                 )
             } else {
                 return Err(VmError::InvalidIteration {
@@ -396,18 +353,6 @@ impl RegoVM {
                     pc: self.pc,
                 });
             }
-        };
-
-        // Snapshot the iteration value register BEFORE the result writeback:
-        // if the compiler ever allocates `result_reg == value_reg_idx`, a
-        // post-writeback read would feed the result accumulator into
-        // `IterationState::Set::current_item`, breaking the next iteration.
-        // Only Set needs this (Object cursor self-advances; Array advances
-        // by index).
-        let set_resume_snapshot = if iter_is_set {
-            Some(self.get_register(value_reg_idx)?.clone())
-        } else {
-            None
         };
 
         // Take ownership of the result register so Rc refcount stays at 1,
@@ -457,13 +402,6 @@ impl RegoVM {
             } = &mut frame.kind
             {
                 if let Some(iter_state) = context.iteration_state.as_mut() {
-                    if let IterationState::Set {
-                        ref mut current_item,
-                        ..
-                    } = *iter_state
-                    {
-                        *current_item = set_resume_snapshot;
-                    }
                     iter_state.advance();
                 }
 
@@ -483,21 +421,26 @@ impl RegoVM {
         if let Some(mut state) = iteration_state_snapshot {
             let has_next = self.setup_next_iteration(&mut state, key_reg_idx, value_reg_idx)?;
 
-            // `setup_next_iteration` advances Object's internal cursor; the
+            // `setup_next_iteration` advances the iteration cursor; the
             // owning frame holds the iteration_state, so we must write the
-            // updated state back. (The Array/Set variants are also unchanged
-            // by copy, so the writeback is uniform.)
+            // updated state back.
             if let Some(frame) = self.execution_stack.get_mut(comprehension_index) {
                 if let FrameKind::Comprehension {
                     ref mut context, ..
                 } = frame.kind
                 {
-                    context.iteration_state = Some(state);
+                    context.iteration_state = Some(state.clone());
                 }
             }
 
             if has_next {
                 if let Some(frame) = self.execution_stack.get_mut(comprehension_index) {
+                    if let FrameKind::Comprehension {
+                        ref mut context, ..
+                    } = frame.kind
+                    {
+                        context.iteration_state = Some(state);
+                    }
                     frame.pc = usize::from(body_start);
                     self.frame_pc_overridden = true;
                 }
@@ -559,16 +502,6 @@ impl RegoVM {
         context: &mut ComprehensionContext,
     ) -> Result<()> {
         if let Some(iter_state) = context.iteration_state.as_mut() {
-            // Snapshot the current value into Set's `current_item` so the
-            // next iteration can resume from `Bound::Excluded(current)`.
-            // Object uses a self-advancing cursor and needs no snapshot here.
-            if let IterationState::Set {
-                ref mut current_item,
-                ..
-            } = *iter_state
-            {
-                *current_item = Some(self.get_register(context.value_reg)?.clone());
-            }
             iter_state.advance();
             let has_next =
                 self.setup_next_iteration(iter_state, context.key_reg, context.value_reg)?;

--- a/src/rvm/vm/context.rs
+++ b/src/rvm/vm/context.rs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 use crate::rvm::instructions::{ComprehensionMode, LoopMode};
-use crate::value::Value;
-use crate::value::{Object, ObjectCursor};
+use crate::value::{Object, ObjectCursor, Set, SetCursor, Value};
 use crate::Rc;
-use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 
 /// Loop execution context for managing iteration state
@@ -33,10 +31,9 @@ pub struct LoopContext {
 /// pre-mutation state. The `ObjectCursor` is opaque and resumes in
 /// O(log n) for the BTree backend.
 ///
-/// `Set` continues to use the pre-existing snapshot-by-cloned-key
-/// approach (`current_item` + `first_iteration`); migration of `Set`
-/// to a cursor-based iterator ships with the `Set` storage abstraction
-/// in a follow-up PR.
+/// Snapshot independence for `Set` follows the same pattern: the shared
+/// `Rc<Set>` keeps the iterator on the pre-mutation state while the opaque
+/// `SetCursor` tracks progress.
 #[derive(Debug, Clone)]
 pub enum IterationState {
     Array {
@@ -48,9 +45,8 @@ pub enum IterationState {
         cursor: ObjectCursor,
     },
     Set {
-        items: Rc<BTreeSet<Value>>,
-        current_item: Option<Value>,
-        first_iteration: bool,
+        set: Rc<Set>,
+        cursor: SetCursor,
     },
     /// Virtual single-element iteration for non-collection values.
     /// Used by Azure Policy's `[*]` on scalar/null fields: presents a single
@@ -75,16 +71,9 @@ impl IterationState {
                 );
                 *index = index.saturating_add(1);
             }
-            // For Object the cursor advances inside `setup_next_iteration`
-            // when it pulls the next item via `Object::next`, so `advance`
-            // is a no-op for the cursor-backed Object variant.
-            Self::Object { .. } => {}
-            Self::Set {
-                ref mut first_iteration,
-                ..
-            } => {
-                *first_iteration = false;
-            }
+            // Cursor-backed variants advance inside `setup_next_iteration`
+            // when they pull the next item via `next`.
+            Self::Object { .. } | Self::Set { .. } => {}
             Self::Single {
                 ref mut consumed, ..
             } => {
@@ -144,7 +133,6 @@ pub(super) struct ComprehensionContext {
 )]
 mod tests {
     use super::*;
-    use crate::value::Object;
 
     /// IterationState::Object holds an `Rc<Object>` plus an opaque cursor.
     /// Mutating an aliased Rc via `Rc::make_mut` allocates a new collection
@@ -167,15 +155,12 @@ mod tests {
             cursor: snapshot_obj.cursor(),
         };
 
-        // Mutate a clone of the source mid-iteration.
         let mut alias = source.clone();
         let inner = alias.as_object_mut().expect("object");
         inner.insert(Value::from("a"), Value::from(999));
         inner.insert(Value::from("d"), Value::from(4));
         inner.remove(&Value::from("b"));
 
-        // Drain the snapshot via the cursor — must still report the original
-        // 3 entries with original values.
         let mut collected: Vec<(Value, Value)> = Vec::new();
         if let IterationState::Object {
             ref obj,
@@ -194,9 +179,48 @@ mod tests {
         assert!(collected.contains(&(Value::from("c"), Value::from(3))));
         assert!(!collected.iter().any(|kv| kv.0 == Value::from("d")));
 
-        // The original source Value (untouched) is also unchanged.
         let src_obj = source.as_object().expect("object");
         assert_eq!(src_obj.len(), 3);
         assert_eq!(src_obj.get(&Value::from("a")), Some(&Value::from(1)));
+    }
+
+    #[test]
+    fn iteration_state_set_is_snapshot_independent_of_source() {
+        let original_set: Set = [1, 2, 3].into_iter().map(Value::from).collect();
+        let mut source = Value::from(original_set.clone());
+        let iter_set = Rc::new(original_set);
+        let iter_cursor = iter_set.cursor();
+        let mut state = IterationState::Set {
+            set: Rc::clone(&iter_set),
+            cursor: iter_cursor,
+        };
+
+        let first = match &mut state {
+            IterationState::Set { set, cursor } => set.next(cursor).cloned(),
+            _ => unreachable!(),
+        };
+        assert_eq!(first, Some(Value::from(1)));
+
+        let source_set = source.as_set_mut().expect("set");
+        source_set.remove(&Value::from(2));
+        source_set.insert(Value::from(4));
+
+        let mut remaining = Vec::new();
+        loop {
+            let next = match &mut state {
+                IterationState::Set { set, cursor } => set.next(cursor).cloned(),
+                _ => unreachable!(),
+            };
+            if let Some(value) = next {
+                remaining.push(value);
+            } else {
+                break;
+            }
+        }
+        assert_eq!(remaining, [Value::from(2), Value::from(3)]);
+        assert!(source
+            .as_set()
+            .map(|source_set| source_set.contains(&Value::from(4)))
+            .unwrap_or(false));
     }
 }

--- a/src/rvm/vm/dispatch.rs
+++ b/src/rvm/vm/dispatch.rs
@@ -3,7 +3,7 @@
 
 use crate::rvm::instructions::{GuardMode, Instruction, LiteralOrRegister};
 use crate::rvm::program::Program;
-use crate::value::Value;
+use crate::value::{Set, Value};
 use alloc::vec::Vec;
 use core::mem;
 
@@ -706,12 +706,12 @@ impl RegoVM {
                     if any_undefined {
                         self.set_register(params.dest, Value::Undefined)?;
                     } else {
-                        let mut set = alloc::collections::BTreeSet::new();
+                        let mut set = Set::new();
                         for &reg in params.element_registers() {
                             set.insert(self.get_register(reg)?.clone());
                         }
 
-                        let set_value = Value::Set(crate::Rc::new(set));
+                        let set_value = Value::from(set);
                         self.set_register(params.dest, set_value)?;
                     }
                     Ok(InstructionOutcome::Continue)

--- a/src/rvm/vm/loops.rs
+++ b/src/rvm/vm/loops.rs
@@ -156,17 +156,6 @@ impl RegoVM {
                 LoopAction::Continue => {}
             }
 
-            // Snapshot the current value for Set so its next iteration can resume
-            // from `Bound::Excluded(current)`. Object uses a cursor and advances
-            // inside `setup_next_iteration` itself.
-            if let &mut IterationState::Set {
-                ref mut current_item,
-                ..
-            } = &mut loop_ctx.iteration_state
-            {
-                *current_item = Some(self.get_register(loop_ctx.value_reg)?.clone());
-            }
-
             loop_ctx.iteration_state.advance();
             let has_next = self.setup_next_iteration(
                 &mut loop_ctx.iteration_state,
@@ -337,8 +326,6 @@ impl RegoVM {
                         }
                     };
 
-                    let value_value = self.get_register(value_reg)?.clone();
-
                     let frame = self
                         .execution_stack
                         .last_mut()
@@ -347,18 +334,6 @@ impl RegoVM {
                         &mut FrameKind::Loop {
                             ref mut context, ..
                         } => {
-                            // Snapshot the current value for Set so its next
-                            // iteration can resume from `Bound::Excluded(current)`.
-                            // Object uses a cursor and advances inside
-                            // `setup_next_iteration` itself.
-                            if let &mut IterationState::Set {
-                                ref mut current_item,
-                                ..
-                            } = &mut context.iteration_state
-                            {
-                                *current_item = Some(value_value);
-                            }
-
                             context.iteration_state.advance();
                             context.current_iteration_failed = false;
 
@@ -378,20 +353,27 @@ impl RegoVM {
                 let has_next =
                     self.setup_next_iteration(&mut iteration_state, key_reg, value_reg)?;
 
-                // `setup_next_iteration` advances Object's internal cursor;
-                // the owning frame holds the iteration_state, so we must
-                // write the updated state back. (Array/Set are unchanged by
-                // the call, so the writeback is uniform.)
+                // `setup_next_iteration` advances the iteration cursor; the
+                // owning frame holds the iteration_state, so we must write the
+                // updated state back.
                 if let Some(frame) = self.execution_stack.last_mut() {
                     if let FrameKind::Loop {
                         ref mut context, ..
                     } = frame.kind
                     {
-                        context.iteration_state = iteration_state;
+                        context.iteration_state = iteration_state.clone();
                     }
                 }
 
                 if has_next {
+                    if let Some(frame) = self.execution_stack.last_mut() {
+                        if let FrameKind::Loop {
+                            ref mut context, ..
+                        } = frame.kind
+                        {
+                            context.iteration_state = iteration_state;
+                        }
+                    }
                     if let Some(frame) = self.execution_stack.last_mut() {
                         if let FrameKind::Loop { ref context, .. } = frame.kind {
                             frame.pc = context.body_resume_pc;
@@ -483,11 +465,9 @@ impl RegoVM {
                     self.handle_empty_collection(mode, params.result_reg, params.loop_end)?;
                     return Ok(None);
                 }
-                Ok(Some(IterationState::Set {
-                    items: set.clone(),
-                    current_item: None,
-                    first_iteration: true,
-                }))
+                let set = set.clone();
+                let cursor = set.cursor();
+                Ok(Some(IterationState::Set { set, cursor }))
             }
             _ => {
                 if self.virtual_element_on_non_collection && *mode == LoopMode::Every {
@@ -568,34 +548,15 @@ impl RegoVM {
                 }
             }
             IterationState::Set {
-                ref items,
-                ref current_item,
-                ref first_iteration,
+                ref set,
+                ref mut cursor,
             } => {
-                if *first_iteration {
-                    if let Some(item) = items.iter().next() {
-                        if key_reg != value_reg {
-                            self.set_register(key_reg, item.clone())?;
-                        }
-                        self.set_register(value_reg, item.clone())?;
-                        Ok(true)
-                    } else {
-                        Ok(false)
+                if let Some(item) = set.next(cursor).cloned() {
+                    if key_reg != value_reg {
+                        self.set_register(key_reg, item.clone())?;
                     }
-                } else if let Some(ref current) = *current_item {
-                    let mut range_iter = items.range((
-                        core::ops::Bound::Excluded(current),
-                        core::ops::Bound::Unbounded,
-                    ));
-                    if let Some(item) = range_iter.next() {
-                        if key_reg != value_reg {
-                            self.set_register(key_reg, item.clone())?;
-                        }
-                        self.set_register(value_reg, item.clone())?;
-                        Ok(true)
-                    } else {
-                        Ok(false)
-                    }
+                    self.set_register(value_reg, item)?;
+                    Ok(true)
                 } else {
                     Ok(false)
                 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -77,7 +77,7 @@ pub enum Value {
     /// A set of values.
     /// No JSON equivalent.
     /// Sets are serialized as arrays in JSON.
-    Set(Rc<BTreeSet<Value>>),
+    Set(Rc<Set>),
 
     /// An object.
     /// Unlike JSON, keys can be any value, not just string.
@@ -322,7 +322,7 @@ impl Value {
     /// # }
     /// ```
     pub fn new_set() -> Value {
-        Value::from(BTreeSet::new())
+        Value::from(Set::new())
     }
 }
 
@@ -786,7 +786,7 @@ impl From<BTreeSet<Value>> for Value {
     /// # Ok(())
     /// # }
     fn from(s: BTreeSet<Value>) -> Self {
-        Value::Set(Rc::new(s))
+        Value::from(Set::from(s))
     }
 }
 
@@ -1244,42 +1244,44 @@ impl Value {
         }
     }
 
-    /// Cast value to [`& BTreeSet<Value>`] if [`Value::Set`].
+    /// Cast value to [`&Set`] if [`Value::Set`].
     /// ```
     /// # use regorus::*;
-    /// # use std::collections::BTreeSet;
+    /// # use regorus::value::Set;
     /// # fn main() -> anyhow::Result<()> {
     /// let v = Value::from(
     ///    [Value::from("Hello")]
     ///        .iter()
     ///        .cloned()
-    ///        .collect::<BTreeSet<Value>>(),
+    ///        .collect::<Set>(),
     /// );
     /// assert_eq!(v.as_set()?.first(), Some(&Value::from("Hello")));
     /// # Ok(())
     /// # }
-    pub fn as_set(&self) -> Result<&BTreeSet<Value>> {
+    /// ```
+    pub fn as_set(&self) -> Result<&Set> {
         match self {
             Value::Set(s) => Ok(s),
             _ => Err(anyhow!("not a set")),
         }
     }
 
-    /// Cast value to [`&mut BTreeSet<Value>`] if [`Value::Set`].
+    /// Cast value to [`&mut Set`] if [`Value::Set`].
     /// ```
     /// # use regorus::*;
-    /// # use std::collections::BTreeSet;
+    /// # use regorus::value::Set;
     /// # fn main() -> anyhow::Result<()> {
     /// let mut v = Value::from(
     ///    [Value::from("Hello")]
     ///        .iter()
     ///        .cloned()
-    ///        .collect::<BTreeSet<Value>>(),
+    ///        .collect::<Set>(),
     /// );
     /// v.as_set_mut()?.insert(Value::from("World"));
     /// # Ok(())
     /// # }
-    pub fn as_set_mut(&mut self) -> Result<&mut BTreeSet<Value>> {
+    /// ```
+    pub fn as_set_mut(&mut self) -> Result<&mut Set> {
         match self {
             Value::Set(s) => Ok(Rc::make_mut(s)),
             _ => Err(anyhow!("not a set")),

--- a/src/value/set/mod.rs
+++ b/src/value/set/mod.rs
@@ -158,7 +158,7 @@ impl Set {
     /// Wrap into a `Value::Set`.
     #[inline]
     pub fn into_value(self) -> Value {
-        Value::Set(crate::Rc::new(self.inner))
+        Value::Set(crate::Rc::new(self))
     }
 
     /// Create a resumable cursor over elements in implementation-defined

--- a/tests/rvm/compiler.rs
+++ b/tests/rvm/compiler.rs
@@ -5,8 +5,8 @@
 use regorus::languages::rego::compiler::Compiler;
 use regorus::rvm::instructions::GuardMode;
 use regorus::rvm::Instruction;
+use regorus::value::Set;
 use regorus::{Engine, Rc, Value};
-use std::collections::BTreeSet;
 
 /// Compile a single-rule Rego module and return the program.
 fn compile_rule(module: &str) -> std::sync::Arc<regorus::rvm::program::Program> {
@@ -71,12 +71,7 @@ fn constant_set_is_hoisted() {
     "#,
     );
     assert_no_collection_create(&program);
-    let expected_set = Value::Set(Rc::new(
-        [1, 2, 3]
-            .into_iter()
-            .map(Value::from)
-            .collect::<BTreeSet<_>>(),
-    ));
+    let expected_set = Value::from([1, 2, 3].into_iter().map(Value::from).collect::<Set>());
     assert_literal_exists(&program, &expected_set);
 }
 


### PR DESCRIPTION
## Summary

- Swap `Value::Set` to store `Rc<value::Set>` and keep `as_set` / `as_set_mut` on the curated storage API.
- Rewrite RVM `IterationState::Set` around `SetCursor`, removing the old `current_item` resume plumbing while preserving snapshot independence via `Rc` copy-on-write.
- Migrate set builtins, compile-time set literals, RVM arithmetic/serialization/metadata, Azure Policy metadata, Azure RBAC helpers, and tests to use `Set` operations.

Stacked on anakrish/regorus#60 (`storage-abstraction-set-foundation`).