### PR TITLE
refactor(value): migrate Value::Array to Array storage abstraction

### DIFF
--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -523,8 +523,9 @@ mod tests {
         assert_eq!(
             r["files"][0]["covered"]
                 .as_array()
-                .map_err(crate::error_to_jsvalue)?,
-            &vec![regorus::Value::from(3)]
+                .map_err(crate::error_to_jsvalue)?
+                .as_slice(),
+            &[regorus::Value::from(3)]
         );
 
         println!("{}", engine1.getCoverageReportPretty()?);

--- a/src/builtins/arrays.rs
+++ b/src/builtins/arrays.rs
@@ -21,9 +21,9 @@ fn concat(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> R
     let name = "array.concat";
     ensure_args_count(span, name, params, args, 2)?;
     let mut v1 = ensure_array(name, &params[0], args[0].clone())?;
-    let mut v2 = ensure_array(name, &params[1], args[1].clone())?;
+    let v2 = ensure_array(name, &params[1], args[1].clone())?;
 
-    Rc::make_mut(&mut v1).append(Rc::make_mut(&mut v2));
+    Rc::make_mut(&mut v1).extend_from_slice(v2.as_slice());
     Ok(Value::Array(v1))
 }
 
@@ -65,6 +65,6 @@ fn slice(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Re
         return Ok(Value::new_array());
     }
 
-    let slice = &array[start..stop];
+    let slice = array.as_slice().get(start..stop).unwrap_or_default();
     Ok(Value::from(slice.to_vec()))
 }

--- a/src/builtins/azure_policy/template_functions_collection.rs
+++ b/src/builtins/azure_policy/template_functions_collection.rs
@@ -59,12 +59,12 @@ fn fn_intersection(
     match *first {
         Value::Array(ref first) => {
             // Intersection of arrays: keep elements from first that appear in all others.
-            let mut result: Vec<Value> = first.as_ref().clone();
+            let mut result: Vec<Value> = first.iter().cloned().collect();
             for arg in rest {
                 let Value::Array(ref other) = *arg else {
                     return Ok(Value::Undefined);
                 };
-                result.retain(|item| other.contains(item));
+                result.retain(|item| other.iter().any(|other_item| other_item == item));
             }
             Ok(Value::from(result))
         }
@@ -149,7 +149,9 @@ fn fn_take(_span: &Span, _params: &[Ref<Expr>], args: &[Value], _strict: bool) -
     match *original {
         Value::Array(ref arr) => {
             let n = count.min(arr.len());
-            Ok(Value::from(arr.get(..n).unwrap_or_default().to_vec()))
+            Ok(Value::from(
+                arr.as_slice().get(..n).unwrap_or_default().to_vec(),
+            ))
         }
         Value::String(ref s) => {
             let taken: alloc::string::String = s.chars().take(count).collect();
@@ -172,7 +174,9 @@ fn fn_skip(_span: &Span, _params: &[Ref<Expr>], args: &[Value], _strict: bool) -
     match *original {
         Value::Array(ref arr) => {
             let n = count.min(arr.len());
-            Ok(Value::from(arr.get(n..).unwrap_or_default().to_vec()))
+            Ok(Value::from(
+                arr.as_slice().get(n..).unwrap_or_default().to_vec(),
+            ))
         }
         Value::String(ref s) => {
             let skipped: alloc::string::String = s.chars().skip(count).collect();

--- a/src/builtins/azure_policy/template_functions_misc.rs
+++ b/src/builtins/azure_policy/template_functions_misc.rs
@@ -8,8 +8,7 @@
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::lexer::Span;
-use crate::value::Object;
-use crate::value::Value;
+use crate::value::{Array, Object, Value};
 use crate::Rc;
 
 use alloc::string::{String, ToString as _};
@@ -90,7 +89,7 @@ fn fn_items(_span: &Span, _params: &[Ref<Expr>], args: &[Value], _strict: bool) 
         entry.insert(Value::from("value"), v.clone());
         result.push(Value::Object(Rc::new(entry)));
     }
-    Ok(Value::Array(Rc::new(result)))
+    Ok(Value::from(Array::from(result)))
 }
 
 // ── indexFromEnd ──────────────────────────────────────────────────────

--- a/src/builtins/graph.rs
+++ b/src/builtins/graph.rs
@@ -188,7 +188,7 @@ fn reachable_paths(
 fn walk_visit(path: &mut Vec<Value>, value: &Value, paths: &mut Vec<Value>) -> Result<()> {
     {
         let path = Value::from_array(path.clone());
-        paths.push(Value::from_array([path, value.clone()].into()));
+        paths.push(Value::from_array(Vec::from([path, value.clone()])));
         // Guard walk result growth when emitting a new path/value pair.
         enforce_limit()?;
     }

--- a/src/builtins/net.rs
+++ b/src/builtins/net.rs
@@ -16,7 +16,7 @@ use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{enforce_limit, ensure_args_count};
 use crate::lexer::Span;
-use crate::value::Value;
+use crate::value::{Array, Value};
 
 use anyhow::{anyhow, bail, Result};
 
@@ -153,7 +153,7 @@ fn _cidr_expand(cidr: Arc<str>) -> Result<Value> {
         enforce_limit()?;
     }
 
-    Ok(Value::Array(Arc::from(hosts)))
+    Ok(Value::from(Array::from(hosts)))
 }
 
 #[cfg(test)]

--- a/src/builtins/objects.rs
+++ b/src/builtins/objects.rs
@@ -349,7 +349,10 @@ fn is_subset(sup: &Value, sub: &Value) -> bool {
             })
         }
         (Value::Set(sup), Value::Set(sub)) => sub.is_subset(sup),
-        (Value::Array(sup), Value::Array(sub)) => sup.windows(sub.len()).any(|w| w == &sub[..]),
+        (Value::Array(sup), Value::Array(sub)) => sup
+            .as_slice()
+            .windows(sub.len())
+            .any(|w| w == sub.as_slice()),
         (Value::Array(sup), Value::Set(_)) => {
             let sup = Value::from_set(sup.iter().cloned().collect());
             is_subset(&sup, sub)

--- a/src/builtins/utils.rs
+++ b/src/builtins/utils.rs
@@ -5,9 +5,8 @@
 use crate::ast::{Expr, Ref};
 use crate::lexer::Span;
 use crate::number::Number;
-use crate::value::Object;
+use crate::value::{Array, Object, Value};
 use crate::Rc;
-use crate::Value;
 use crate::*;
 
 use alloc::collections::BTreeSet;
@@ -149,7 +148,7 @@ pub fn ensure_string_collection<'a>(fcn: &str, arg: &Expr, v: &'a Value) -> Resu
     Ok(collection)
 }
 
-pub fn ensure_array(fcn: &str, arg: &Expr, v: Value) -> Result<Rc<Vec<Value>>> {
+pub fn ensure_array(fcn: &str, arg: &Expr, v: Value) -> Result<Rc<Array>> {
     Ok(match v {
         Value::Array(a) => a,
         _ => {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2260,7 +2260,7 @@ impl Interpreter {
                     let key = self.eval_expr(key)?;
                     collection[&key] == value
                 } else {
-                    array.contains(&value)
+                    array.iter().any(|item| item == &value)
                 }
             }
             Value::Object(object) => {
@@ -3733,7 +3733,7 @@ impl Interpreter {
                         if value != Value::Undefined {
                             for (path, value_in_map) in value.as_object()? {
                                 let mut full_path = package_components.clone();
-                                full_path.append(&mut path.as_array()?.clone());
+                                full_path.extend(path.as_array()?.iter().cloned());
                                 self.check_rule_path(refr, &full_path, value_in_map, is_set)?;
                                 self.update_rule_value(
                                     span,

--- a/src/languages/azure_policy/aliases/obj_map.rs
+++ b/src/languages/azure_policy/aliases/obj_map.rs
@@ -12,9 +12,8 @@ use alloc::vec::Vec;
 
 use hashbrown::HashMap;
 
-use crate::value::Object;
+use crate::value::{Array, Object, Value};
 use crate::Rc;
-use crate::Value;
 
 /// A string-keyed map of JSON values.
 ///
@@ -93,7 +92,7 @@ pub fn make_value(map: ObjMap) -> Value {
 
 /// Convert a `Vec<Value>` into a `Value::Array`.
 pub fn make_array(items: Vec<Value>) -> Value {
-    Value::Array(Rc::new(items))
+    Value::from(Array::from(items))
 }
 
 /// Extract a `&str` from a `Value::String`.

--- a/src/languages/azure_rbac/builtins/common.rs
+++ b/src/languages/azure_rbac/builtins/common.rs
@@ -191,7 +191,7 @@ pub(super) const fn is_collection(value: &Value) -> bool {
 // Check membership in an array or set.
 pub(super) fn collection_contains(collection: &Value, needle: &Value) -> bool {
     match *collection {
-        Value::Array(ref list) => list.contains(needle),
+        Value::Array(ref list) => list.iter().any(|item| item == needle),
         Value::Set(ref set) => set.contains(needle),
         _ => false,
     }

--- a/src/languages/azure_rbac/builtins/lists.rs
+++ b/src/languages/azure_rbac/builtins/lists.rs
@@ -11,7 +11,7 @@ use super::evaluator::RbacBuiltinError;
 pub(super) fn list_contains(left: &Value, right: &Value) -> Result<bool, RbacBuiltinError> {
     match *left {
         // Lists and sets share containment semantics.
-        Value::Array(ref list) => Ok(list_contains_values(list, right)),
+        Value::Array(ref list) => Ok(list_contains_values(list.as_slice(), right)),
         Value::Set(ref set) => Ok(set_contains_values(set, right)),
         _ => Ok(false),
     }

--- a/src/languages/rego/compiler/expressions/collection_literals.rs
+++ b/src/languages/rego/compiler/expressions/collection_literals.rs
@@ -11,7 +11,7 @@ use crate::ast::{Expr, ExprRef};
 use crate::lexer::Span;
 use crate::rvm::instructions::{ArrayCreateParams, ObjectCreateParams, SetCreateParams};
 use crate::rvm::Instruction;
-use crate::value::Object;
+use crate::value::{Array, Object};
 use crate::{Rc, Value};
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
@@ -35,7 +35,7 @@ pub(in crate::languages::rego::compiler) fn try_eval_const(expr: &Expr) -> Optio
             .iter()
             .map(|i| try_eval_const(i.as_ref()))
             .collect::<Option<Vec<_>>>()
-            .map(|v| Value::Array(Rc::new(v))),
+            .map(|v| Value::from(Array::from(v))),
         Expr::Set { items, .. } => items
             .iter()
             .map(|i| try_eval_const(i.as_ref()))
@@ -59,7 +59,7 @@ impl<'a> Compiler<'a> {
         let all_const: Option<Vec<_>> = items.iter().map(|i| try_eval_const(i.as_ref())).collect();
         if let Some(values) = all_const {
             let dest = self.alloc_register();
-            let literal_idx = self.add_literal(Value::Array(Rc::new(values)));
+            let literal_idx = self.add_literal(Value::from(Array::from(values)));
             self.emit_instruction(Instruction::Load { dest, literal_idx }, span);
             return Ok(dest);
         }

--- a/src/rvm/program/metadata.rs
+++ b/src/rvm/program/metadata.rs
@@ -208,7 +208,7 @@ impl MetadataValue {
             MetadataValue::Integer(n) => Value::from(n),
             MetadataValue::List(ref list) => {
                 let values: Vec<Value> = list.iter().map(MetadataValue::to_value).collect();
-                Value::Array(Rc::new(values))
+                Value::from(crate::value::Array::from(values))
             }
             MetadataValue::Map(ref map) => {
                 let mut obj = Object::new();

--- a/src/rvm/program/serialization/value.rs
+++ b/src/rvm/program/serialization/value.rs
@@ -11,8 +11,7 @@ use serde::ser::{SerializeSeq as _, SerializeTuple as _};
 use serde::{Deserialize, Serialize};
 
 use crate::number::Number;
-use crate::value::Object;
-use crate::value::Value;
+use crate::value::{Array, Object, Value};
 
 const VARIANT_NULL: u32 = 0;
 const VARIANT_BOOL: u32 = 1;
@@ -81,7 +80,7 @@ impl<'a> Serialize for BinaryValueRef<'a> {
                 "BinaryValue",
                 VARIANT_ARRAY,
                 "Array",
-                &BinaryValueSlice(items.as_slice()),
+                &BinaryArrayRef(items.as_ref()),
             ),
             Value::Set(ref items) => serializer.serialize_newtype_variant(
                 "BinaryValue",
@@ -99,6 +98,22 @@ impl<'a> Serialize for BinaryValueRef<'a> {
                 serializer.serialize_unit_variant("BinaryValue", VARIANT_UNDEFINED, "Undefined")
             }
         }
+    }
+}
+
+/// Array wrapper allowing zero-copy serialization of value collections.
+pub struct BinaryArrayRef<'a>(pub &'a Array);
+
+impl<'a> Serialize for BinaryArrayRef<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for value in self.0.iter() {
+            seq.serialize_element(&BinaryValueRef(value))?;
+        }
+        seq.end()
     }
 }
 
@@ -249,7 +264,7 @@ impl<'de> Visitor<'de> for BinaryValueVisitor {
             }
             (BinaryVariant::Array, variant) => {
                 let items: Vec<BinaryValue> = variant.newtype_variant()?;
-                let values: Vec<Value> = items.into_iter().map(BinaryValue::into_value).collect();
+                let values: Array = items.into_iter().map(BinaryValue::into_value).collect();
                 Ok(BinaryValue(Value::from(values)))
             }
             (BinaryVariant::Set, variant) => {

--- a/src/rvm/vm/comprehension.rs
+++ b/src/rvm/vm/comprehension.rs
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::rvm::instructions::{ComprehensionBeginParams, ComprehensionMode};
-use crate::value::Object;
-use crate::value::Value;
+use crate::value::{Object, Value};
 use crate::Rc;
 use alloc::format;
 use alloc::sync::Arc;
@@ -46,7 +45,10 @@ impl RegoVM {
                     if items.is_empty() {
                         None
                     } else {
-                        Some(IterationState::Array { items, index: 0 })
+                        Some(IterationState::Array {
+                            cursor: items.cursor(),
+                            arr: items,
+                        })
                     }
                 }
                 Value::Object(obj) => {
@@ -133,7 +135,10 @@ impl RegoVM {
                     if items.is_empty() {
                         None
                     } else {
-                        Some(IterationState::Array { items, index: 0 })
+                        Some(IterationState::Array {
+                            cursor: items.cursor(),
+                            arr: items,
+                        })
                     }
                 }
                 Value::Object(obj) => {
@@ -483,16 +488,15 @@ impl RegoVM {
         if let Some(mut state) = iteration_state_snapshot {
             let has_next = self.setup_next_iteration(&mut state, key_reg_idx, value_reg_idx)?;
 
-            // `setup_next_iteration` advances Object's internal cursor; the
+            // `setup_next_iteration` advances the iteration cursor; the
             // owning frame holds the iteration_state, so we must write the
-            // updated state back. (The Array/Set variants are also unchanged
-            // by copy, so the writeback is uniform.)
+            // updated state back.
             if let Some(frame) = self.execution_stack.get_mut(comprehension_index) {
                 if let FrameKind::Comprehension {
                     ref mut context, ..
                 } = frame.kind
                 {
-                    context.iteration_state = Some(state);
+                    context.iteration_state = Some(state.clone());
                 }
             }
 

--- a/src/rvm/vm/context.rs
+++ b/src/rvm/vm/context.rs
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 use crate::rvm::instructions::{ComprehensionMode, LoopMode};
-use crate::value::Value;
-use crate::value::{Object, ObjectCursor};
+use crate::value::{Array, ArrayCursor, Object, ObjectCursor, Value};
 use crate::Rc;
 use alloc::collections::BTreeSet;
+
+#[cfg(test)]
 use alloc::vec::Vec;
 
 /// Loop execution context for managing iteration state
@@ -40,8 +41,8 @@ pub struct LoopContext {
 #[derive(Debug, Clone)]
 pub enum IterationState {
     Array {
-        items: Rc<Vec<Value>>,
-        index: usize,
+        arr: Rc<Array>,
+        cursor: ArrayCursor,
     },
     Object {
         obj: Rc<Object>,
@@ -64,21 +65,9 @@ pub enum IterationState {
 impl IterationState {
     pub(super) const fn advance(&mut self) {
         match *self {
-            Self::Array { ref mut index, .. } => {
-                // Array iteration uses `usize` as the cursor and advances via
-                // `saturating_add(1)`. A cursor already at `usize::MAX` here
-                // means a stuck (non-progressing) iteration was emitted by
-                // malformed bytecode; assert in debug to surface it loudly.
-                debug_assert!(
-                    *index < usize::MAX,
-                    "IterationState::Array index already at usize::MAX on advance"
-                );
-                *index = index.saturating_add(1);
-            }
-            // For Object the cursor advances inside `setup_next_iteration`
-            // when it pulls the next item via `Object::next`, so `advance`
-            // is a no-op for the cursor-backed Object variant.
-            Self::Object { .. } => {}
+            // Cursor-backed variants advance inside `setup_next_iteration`
+            // when they pull the next item via `next`.
+            Self::Array { .. } | Self::Object { .. } => {}
             Self::Set {
                 ref mut first_iteration,
                 ..
@@ -144,7 +133,6 @@ pub(super) struct ComprehensionContext {
 )]
 mod tests {
     use super::*;
-    use crate::value::Object;
 
     /// IterationState::Object holds an `Rc<Object>` plus an opaque cursor.
     /// Mutating an aliased Rc via `Rc::make_mut` allocates a new collection
@@ -167,15 +155,12 @@ mod tests {
             cursor: snapshot_obj.cursor(),
         };
 
-        // Mutate a clone of the source mid-iteration.
         let mut alias = source.clone();
         let inner = alias.as_object_mut().expect("object");
         inner.insert(Value::from("a"), Value::from(999));
         inner.insert(Value::from("d"), Value::from(4));
         inner.remove(&Value::from("b"));
 
-        // Drain the snapshot via the cursor — must still report the original
-        // 3 entries with original values.
         let mut collected: Vec<(Value, Value)> = Vec::new();
         if let IterationState::Object {
             ref obj,
@@ -194,9 +179,35 @@ mod tests {
         assert!(collected.contains(&(Value::from("c"), Value::from(3))));
         assert!(!collected.iter().any(|kv| kv.0 == Value::from("d")));
 
-        // The original source Value (untouched) is also unchanged.
         let src_obj = source.as_object().expect("object");
         assert_eq!(src_obj.len(), 3);
         assert_eq!(src_obj.get(&Value::from("a")), Some(&Value::from(1)));
+    }
+
+    #[test]
+    fn iteration_state_array_is_snapshot_independent_of_source() {
+        let source_snapshot = Rc::new(Array::from_iter([Value::from(1), Value::from(2)]));
+        let mut source = Value::Array(Rc::clone(&source_snapshot));
+        let state = IterationState::Array {
+            arr: Rc::clone(&source_snapshot),
+            cursor: source_snapshot.cursor(),
+        };
+
+        if let Value::Array(ref mut source_arr) = source {
+            Rc::make_mut(source_arr).push(Value::from(3));
+        }
+
+        let IterationState::Array {
+            arr: state_arr,
+            mut cursor,
+        } = state
+        else {
+            unreachable!();
+        };
+        assert_eq!(state_arr.len(), 2);
+        assert_eq!(state_arr.next(&mut cursor), Some((0, &Value::from(1))));
+        assert_eq!(state_arr.next(&mut cursor), Some((1, &Value::from(2))));
+        assert_eq!(state_arr.next(&mut cursor), None);
+        assert_eq!(source.as_array().map(Array::len).ok(), Some(3));
     }
 }

--- a/src/rvm/vm/dispatch.rs
+++ b/src/rvm/vm/dispatch.rs
@@ -3,7 +3,7 @@
 
 use crate::rvm::instructions::{GuardMode, Instruction, LiteralOrRegister};
 use crate::rvm::program::Program;
-use crate::value::Value;
+use crate::value::{Array, Value};
 use alloc::vec::Vec;
 use core::mem;
 
@@ -583,7 +583,7 @@ impl RegoVM {
                 }
             }
             ArrayNew { dest } => {
-                let empty_array = Value::Array(crate::Rc::new(Vec::new()));
+                let empty_array = Value::new_array();
                 self.set_register(dest, empty_array)?;
                 Ok(InstructionOutcome::Continue)
             }
@@ -656,7 +656,7 @@ impl RegoVM {
                             .map(|&reg| self.get_register(reg).cloned())
                             .collect::<Result<Vec<_>>>()?;
 
-                        let array_value = Value::Array(crate::Rc::new(elements));
+                        let array_value = Value::from(Array::from(elements));
                         self.set_register(params.dest, array_value)?;
                     }
                     Ok(InstructionOutcome::Continue)
@@ -736,7 +736,7 @@ impl RegoVM {
                         Value::Bool(set_elements.contains(value_to_check))
                     }
                     Value::Array(ref array_items) => {
-                        Value::Bool(array_items.contains(value_to_check))
+                        Value::Bool(array_items.iter().any(|item| item == value_to_check))
                     }
                     Value::Object(ref object_fields) => {
                         Value::Bool(object_fields.values().any(|v| v == value_to_check))

--- a/src/rvm/vm/loops.rs
+++ b/src/rvm/vm/loops.rs
@@ -378,10 +378,9 @@ impl RegoVM {
                 let has_next =
                     self.setup_next_iteration(&mut iteration_state, key_reg, value_reg)?;
 
-                // `setup_next_iteration` advances Object's internal cursor;
-                // the owning frame holds the iteration_state, so we must
-                // write the updated state back. (Array/Set are unchanged by
-                // the call, so the writeback is uniform.)
+                // `setup_next_iteration` advances the iteration cursor; the
+                // owning frame holds the iteration_state, so we must write the
+                // updated state back.
                 if let Some(frame) = self.execution_stack.last_mut() {
                     if let FrameKind::Loop {
                         ref mut context, ..
@@ -445,8 +444,8 @@ impl RegoVM {
                     return Ok(None);
                 }
                 Ok(Some(IterationState::Array {
-                    items: items.clone(),
-                    index: 0,
+                    cursor: items.cursor(),
+                    arr: items.clone(),
                 }))
             }
             Value::Object(ref obj) => {
@@ -530,20 +529,15 @@ impl RegoVM {
     ) -> Result<bool> {
         match *state {
             IterationState::Array {
-                ref items,
-                ref index,
+                ref arr,
+                ref mut cursor,
             } => {
-                if *index < items.len() {
+                if let Some((index, value)) = arr.next(cursor) {
                     if key_reg != value_reg {
-                        let key_value = Value::from(*index);
-                        self.set_register(key_reg, key_value)?;
+                        self.set_register(key_reg, Value::from(index))?;
                     }
-                    if let Some(item_value) = items.get(*index).cloned() {
-                        self.set_register(value_reg, item_value)?;
-                        Ok(true)
-                    } else {
-                        Ok(false)
-                    }
+                    self.set_register(value_reg, value.clone())?;
+                    Ok(true)
                 } else {
                     Ok(false)
                 }

--- a/src/schema/tests/suite.rs
+++ b/src/schema/tests/suite.rs
@@ -978,7 +978,9 @@ fn test_deserialize_array_items_with_fields() {
             assert_eq!(max_items, &Some(2));
             assert_eq!(
                 default,
-                &Some(Value::Array(Rc::new(vec![Value::from("bar")])))
+                &Some(Value::from(crate::value::Array::from(vec![Value::from(
+                    "bar"
+                )])))
             );
             match items.as_type() {
                 Type::String {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -41,7 +41,7 @@ impl<'de> Deserialize<'de> for ValueOrVec {
         let value = Value::deserialize(deserializer)?;
 
         match &value["many!"] {
-            Value::Array(arr) => Ok(ValueOrVec::Many(arr.to_vec())),
+            Value::Array(arr) => Ok(ValueOrVec::Many(arr.as_slice().to_vec())),
             _ => Ok(ValueOrVec::Single(value)),
         }
     }

--- a/src/tests/interpreter/mod.rs
+++ b/src/tests/interpreter/mod.rs
@@ -337,7 +337,10 @@ fn push_query_results(query_results: QueryResults, results: &mut Vec<Value>) {
                 results.push(r.bindings.clone());
             } else {
                 results.push(Value::from_array(
-                    r.expressions.iter().map(|e| e.value.clone()).collect(),
+                    r.expressions
+                        .iter()
+                        .map(|e| e.value.clone())
+                        .collect::<Vec<_>>(),
                 ));
             }
         }

--- a/src/value/array/mod.rs
+++ b/src/value/array/mod.rs
@@ -12,6 +12,7 @@ use core::fmt;
 use core::ops;
 
 use crate::value::Value;
+use crate::Rc;
 
 #[cfg(feature = "rvm")]
 #[allow(unused_imports)] // surface for downstream PRs
@@ -175,7 +176,7 @@ impl Array {
     /// Wrap into a `Value::Array`.
     #[inline]
     pub fn into_value(self) -> Value {
-        Value::Array(crate::Rc::new(self.inner))
+        Value::Array(Rc::new(self))
     }
 
     /// Create a resumable cursor over elements in sequence order. O(1).

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -19,6 +19,9 @@ mod tests;
 
 #[allow(unused_imports)] // surface for downstream PRs
 pub use array::Array;
+#[cfg(feature = "rvm")]
+#[allow(unused_imports)] // surface for downstream PRs
+pub use array::Cursor as ArrayCursor;
 #[allow(unused_imports)] // surface for downstream PRs
 pub use object::{IntoIter, Iter, IterMut, Object};
 
@@ -69,7 +72,7 @@ pub enum Value {
     String(Rc<str>),
 
     /// JSON array.
-    Array(Rc<Vec<Value>>),
+    Array(Rc<Array>),
 
     /// A set of values.
     /// No JSON equivalent.
@@ -210,7 +213,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         V: SeqAccess<'de>,
     {
-        let mut arr = vec![];
+        let mut arr = Array::new();
         while let Some(v) = visitor.next_element()? {
             arr.push(v);
             // Enforce allocator limit while expanding a deserialized array.
@@ -291,7 +294,7 @@ impl Value {
     /// # }
     /// ```
     pub fn new_array() -> Value {
-        Value::from(vec![])
+        Value::from(Array::new())
     }
 
     /// Create an empty [`Value::Object`]
@@ -761,7 +764,7 @@ impl From<Vec<Value>> for Value {
     /// # Ok(())
     /// # }
     fn from(a: Vec<Value>) -> Self {
-        Value::Array(Rc::new(a))
+        Value::Array(Rc::new(Array::from(a)))
     }
 }
 
@@ -809,8 +812,8 @@ impl From<BTreeMap<Value, Value>> for Value {
 }
 
 impl Value {
-    pub(crate) fn from_array(a: Vec<Value>) -> Value {
-        Value::from(a)
+    pub(crate) fn from_array<A: Into<Array>>(a: A) -> Value {
+        Value::from(a.into())
     }
 
     pub(crate) fn from_set(s: BTreeSet<Value>) -> Value {
@@ -1211,7 +1214,7 @@ impl Value {
         }
     }
 
-    /// Cast value to [`& Vec<Value>`] if [`Value::Array`].
+    /// Cast value to [`& Array`] if [`Value::Array`].
     /// ```
     /// # use regorus::*;
     /// # fn main() -> anyhow::Result<()> {
@@ -1219,14 +1222,14 @@ impl Value {
     /// assert_eq!(v.as_array()?[0], Value::from("Hello"));
     /// # Ok(())
     /// # }
-    pub fn as_array(&self) -> Result<&Vec<Value>> {
+    pub fn as_array(&self) -> Result<&Array> {
         match self {
             Value::Array(a) => Ok(a),
             _ => Err(anyhow!("not an array")),
         }
     }
 
-    /// Cast value to [`&mut Vec<Value>`] if [`Value::Array`].
+    /// Cast value to [`&mut Array`] if [`Value::Array`].
     /// ```
     /// # use regorus::*;
     /// # fn main() -> anyhow::Result<()> {
@@ -1234,7 +1237,7 @@ impl Value {
     /// v.as_array_mut()?.push(Value::from("World"));
     /// # Ok(())
     /// # }
-    pub fn as_array_mut(&mut self) -> Result<&mut Vec<Value>> {
+    pub fn as_array_mut(&mut self) -> Result<&mut Array> {
         match self {
             Value::Array(a) => Ok(Rc::make_mut(a)),
             _ => Err(anyhow!("not an array")),

--- a/src/value/tests.rs
+++ b/src/value/tests.rs
@@ -701,14 +701,14 @@ fn array_sort_dedup_and_reverse() {
 #[test]
 fn array_conversions_to_value() {
     let array = Array::from_iter([val(1), val(2), val(3)]);
-    let expected = Value::Array(crate::Rc::new(vec![val(1), val(2), val(3)]));
+    let expected = Value::from(Array::from_iter([val(1), val(2), val(3)]));
     let value_from_impl = Value::from(array.clone());
     assert_eq!(value_from_impl, expected);
 
     let value_from_method = array.into_value();
     assert_eq!(
         value_from_method,
-        Value::Array(crate::Rc::new(vec![val(1), val(2), val(3)]))
+        Value::from(Array::from_iter([val(1), val(2), val(3)]))
     );
 }
 


### PR DESCRIPTION
## Summary
- Swap Value::Array payload storage from Vec<Value> to value::Array while preserving Vec<Value> conversion compatibility.
- Update as_array/as_array_mut to expose Array and delegate Value construction through Array::into_value.
- Serialize RVM binary array payloads via Array-aware references and deserialize into Array.
- Rewrite IterationState::Array around ArrayCursor; setup_next_iteration now self-advances and advance() is a no-op.
- Migrate array builtins, interpreter/RVM sites, metadata, Azure helpers, schema/value tests, and the WASM binding test to the Array API.

## Judgment calls
- Kept Value::from(Vec<Value>) and made the internal from_array helper generic for compatibility while storing Array internally.
- Added no new foundation methods; used existing Array APIs/as_slice where needed.

## Validation
- cargo +1.92.0 xtask fmt
- cargo +1.92.0 xtask clippy
- cargo +1.92.0 test --lib --all-features
- cargo +1.92.0 test --doc --all-features
- cargo +1.92.0 test --all-features